### PR TITLE
add GitHub Issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug Report
+about: Create a report to help us squash a bug
+title: "[BUG] "
+labels: bug
+assignees: ""
+---
+
+## 🐛 The Bug
+
+[Provide a clear and concise description of what the bug is.]
+
+## 🔁 Steps to Reproduce
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See the error / weird behavior.
+
+## 🎯 Expected Behavior
+
+[What *should* have happened?]
+
+## 💻 Environment
+
+- **Device:** [e.g., Desktop, iPhone 15]
+- **OS:** [e.g., macOS, Windows, iOS]
+- **Browser:** [e.g., Chrome, Safari, Firefox]
+
+## 📸 Screenshots / Screen Recording
+
+[Drop screenshots or video files here. Visual proof is the best proof!]
+
+## 💡 Additional Context (Optional)
+
+[Any console errors, network request failures, or theories on what broke?]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest an idea for the HuLA project
+title: "[FEATURE] "
+labels: enhancement
+assignees: ""
+---
+
+## 🤔 The Problem
+
+[Is this feature request related to a specific problem? e.g., "I'm always frustrated when..." or "As a user, I need a way to..."]
+
+## ✨ Proposed Solution
+
+[Describe the feature or solution you'd like to see built. How should it work?]
+
+## 🚧 Alternatives Considered
+
+[Did you think about any other ways to solve this? Are there any current workarounds?]
+
+## 🎨 Mockups / Visuals
+
+[Drop any design assets, UI wireframes, or examples from other websites here.]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## 🔗 Linked Issue
+
+Closes #[Insert issue number here - e.g., Closes #12]
+
+## 📝 Description
+
+[Briefly explain what this PR does. What did you change, and why?]
+
+## 🚀 Type of Change
+
+- [ ] 🐛 Bug fix
+- [ ] ✨ New feature
+- [ ] 🛠️ Refactor / Chore (Code cleanup, dependency update, etc.)
+
+## 🧪 How to Test
+
+[Provide clear steps for the reviewer to manually test your UI or API changes.]
+
+1. Pull down this branch and run `npm run dev`
+2. Navigate to '...'
+3. Do '...' and verify that '...' happens.
+
+## ✅ Pre-Merge Checklist
+
+- [ ] I have performed a self-review of my own code.
+- [ ] I have removed all temporary `console.log`s and debuggers.
+- [ ] I have successfully rebased / resolved any merge conflicts with `main`.
+- [ ] UI looks good on both desktop and mobile viewports.


### PR DESCRIPTION
Adds standardized Markdown templates for Bug Reports, Feature Requests, and Pull Requests to the `.github` folder.

This will help keep our repo organized by prompting the team to provide necessary context (like environment details for bugs or UI mockups for features) right off the bat, and pre-filling a quick self-review checklist for all future PRs.
No application code changes, just workflow additions!