### PR TITLE
backend listen on network

### DIFF
--- a/server.js
+++ b/server.js
@@ -26,6 +26,7 @@ dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+const HOST = process.env.HOST || '0.0.0.0'; // 0.0.0.0 = accept connections from network (e.g. phone on same Wi‑Fi)
 const API_KEY = process.env.API_KEY;
 const rawOrigins = process.env.CORS_ORIGIN || process.env.FRONTEND_ORIGIN || 'https://hunterlogic.vercel.app';
 const allowedOrigins = rawOrigins.split(',').map((origin) => origin.trim()).filter(Boolean);
@@ -85,8 +86,8 @@ app.use('/api/instructor', instructorRouter);
 
 app.use(errorHandler);
 
-app.listen(PORT, () => {
-  console.log(`Server is running on port ${PORT}`);
+app.listen(PORT, HOST, () => {
+  console.log(`Server is running on http://${HOST}:${PORT}`);
 });
 
 const autoSubmitInterval = scheduleAutoSubmitSweep();


### PR DESCRIPTION
## Summary

Makes the API server listen on all interfaces so you can reach it from other devices on the same network (e.g. your phone) during local development.

## Changes

- **`server.js`**
  - Read bind address from `process.env.HOST`, defaulting to `'0.0.0.0'` instead of only `localhost`.
  - Pass that host to `app.listen(PORT, HOST, ...)` so the server accepts connections from the network.

## Usage

- Default: server binds to `0.0.0.0` and is reachable at `http://<your-machine-ip>:3000` from other devices.
- Override with `HOST=127.0.0.1` in `.env` to restrict to localhost only.