### PR TITLE
Fix CP and IP correctness

### DIFF
--- a/__tests__/derivation-hurley.test.js
+++ b/__tests__/derivation-hurley.test.js
@@ -1,0 +1,153 @@
+import checkDerivation from '../lib/logicpenguin/checkers/derivation-hurley.js';
+
+function buildProof({ conclusion, lines, premises = [] }) {
+  return {
+    parts: [
+      {
+        showline: { s: conclusion, j: '', isMainConclusion: true, n: '' },
+        parts: lines.map((line, index) => ({
+          n: String(index + 1),
+          s: line.formula,
+          j: line.justification ?? '',
+        })),
+      },
+    ],
+    prems: premises,
+    conc: conclusion,
+  };
+}
+
+async function runDerivation({ premises = [], conclusion, lines }) {
+  return checkDerivation(
+    { prems: premises, conc: conclusion },
+    null,
+    buildProof({ conclusion, lines, premises }),
+    false,
+    1,
+    false,
+    {}
+  );
+}
+
+function collectMessages(errors = {}) {
+  const messages = [];
+  for (const categories of Object.values(errors)) {
+    for (const severities of Object.values(categories || {})) {
+      for (const items of Object.values(severities || {})) {
+        messages.push(...Object.keys(items || {}));
+      }
+    }
+  }
+  return messages;
+}
+
+describe('derivation-hurley ACP/AIP completion', () => {
+  // this one catches the old bug where an open acp could still look complete
+  it('rejects a conclusion that appears only inside an unresolved ACP', async () => {
+    const result = await runDerivation({
+      conclusion: 'A',
+      lines: [
+        { formula: 'A', justification: 'ACP' },
+      ],
+    });
+
+    expect(result.successstatus).toBe('incorrect');
+    expect(collectMessages(result.errors)).toEqual(
+      expect.arrayContaining([
+        'open ACP/AIP subderivations must be closed with CP/IP before the proof is complete',
+        'final conclusion of argument not shown',
+      ])
+    );
+  });
+
+  // same bug but for indirect proof assumptions
+  it('rejects a conclusion that appears only inside an unresolved AIP', async () => {
+    const result = await runDerivation({
+      conclusion: 'A',
+      lines: [
+        { formula: 'A', justification: 'AIP' },
+      ],
+    });
+
+    expect(result.successstatus).toBe('incorrect');
+    expect(collectMessages(result.errors)).toEqual(
+      expect.arrayContaining([
+        'open ACP/AIP subderivations must be closed with CP/IP before the proof is complete',
+        'final conclusion of argument not shown',
+      ])
+    );
+  });
+
+  // even if the conclusion showed up earlier the proof stays open until cp or ip closes it
+  it('rejects a proof with an unresolved ACP after a main-scope conclusion is shown', async () => {
+    const result = await runDerivation({
+      premises: ['A'],
+      conclusion: 'A',
+      lines: [
+        { formula: 'A', justification: 'Pr' },
+        { formula: 'B', justification: 'ACP' },
+      ],
+    });
+
+    expect(result.successstatus).toBe('incorrect');
+    expect(collectMessages(result.errors)).toContain(
+      'open ACP/AIP subderivations must be closed with CP/IP before the proof is complete'
+    );
+  });
+
+  // old false positive where the target formula appeared on an acp line
+  it('rejects a conditional proof target that is entered as ACP instead of CP', async () => {
+    const result = await runDerivation({
+      premises: ['A⊃P'],
+      conclusion: '(A•B)⊃(P∨Q)',
+      lines: [
+        { formula: 'A⊃P', justification: 'Pr' },
+        { formula: 'A•B', justification: 'ACP' },
+        { formula: 'A', justification: '2 Simp' },
+        { formula: 'P', justification: '1,3 MP' },
+        { formula: 'P∨Q', justification: '4 Add' },
+        { formula: '(A•B)⊃(P∨Q)', justification: 'ACP' },
+      ],
+    });
+
+    expect(result.successstatus).toBe('incorrect');
+    expect(collectMessages(result.errors)).toEqual(
+      expect.arrayContaining([
+        'open ACP/AIP subderivations must be closed with CP/IP before the proof is complete',
+        'final conclusion of argument not shown',
+      ])
+    );
+  });
+
+  // this is the path that should still pass
+  it('accepts a properly discharged ACP/CP derivation', async () => {
+    const result = await runDerivation({
+      premises: ['A'],
+      conclusion: 'B⊃A',
+      lines: [
+        { formula: 'A', justification: 'Pr' },
+        { formula: 'B', justification: 'ACP' },
+        { formula: 'A', justification: '' },
+        { formula: 'B⊃A', justification: '2-3 CP' },
+      ],
+    });
+
+    expect(result.successstatus).toBe('correct');
+  });
+
+  // and this is the matching indirect proof path
+  it('accepts a properly discharged AIP/IP derivation', async () => {
+    const result = await runDerivation({
+      premises: ['A•~A'],
+      conclusion: '~B',
+      lines: [
+        { formula: 'A•~A', justification: 'Pr' },
+        { formula: 'B', justification: 'AIP' },
+        { formula: 'A•~A', justification: '' },
+        { formula: '~B', justification: '2-3 IP' },
+      ],
+    });
+
+    expect(result.successstatus).toBe('correct');
+  });
+});

--- a/lib/logicpenguin/checkers/derivation-check.js
+++ b/lib/logicpenguin/checkers/derivation-check.js
@@ -166,13 +166,37 @@ export default class DerivationCheck {
 
     checkConc() {
         const Formula = this.Formula;
+        let hasMainScopeConclusion = false;
+        let lastSubstantiveLine = null;
         for (const line of (this.deriv.lines ?? [])) {
             if (!line) { continue; }
+            if ((line.s && line.s.trim()) || (line.j && line.j.trim())) {
+                lastSubstantiveLine = line;
+            }
             const lineNorm = line.formulaNormal ??
                 (line.s ? Formula.from(line.s).normal : '');
-            if (lineNorm == this.conc) {
-                return;
+            const openAssumptions = Array.isArray(line?.openAssumptions)
+                ? line.openAssumptions
+                : [];
+            // only a conclusion in the main proof scope can finish the proof
+            if (lineNorm === this.conc && openAssumptions.length === 0) {
+                hasMainScopeConclusion = true;
             }
+        }
+        const unresolvedAssumptions = Array.isArray(lastSubstantiveLine?.openAssumptions)
+            ? lastSubstantiveLine.openAssumptions
+            : [];
+        // the last real line tells us whether an acp or aip is still open
+        if (unresolvedAssumptions.length > 0) {
+            this.adderror(
+                lastSubstantiveLine?.n || '1',
+                "completion",
+                "high",
+                "open ACP/AIP subderivations must be closed with CP/IP before the proof is complete"
+            );
+        }
+        if (hasMainScopeConclusion) {
+            return;
         }
         
         // we attach the error to line one, which we really shouldn't but

--- a/lib/logicpenguin/checkers/derivation-check.js
+++ b/lib/logicpenguin/checkers/derivation-check.js
@@ -188,6 +188,27 @@ export default class DerivationCheck {
             : [];
         // the last real line tells us whether an acp or aip is still open
         if (unresolvedAssumptions.length > 0) {
+            const unresolvedRules = new Set(
+                unresolvedAssumptions.map((assumptionLine) =>
+                    this.resolveRuleName(assumptionLine)
+                )
+            );
+            if (unresolvedRules.has('ACP')) {
+                this.adderror(
+                    lastSubstantiveLine?.n || '1',
+                    "dependency",
+                    "low",
+                    "Conditional Proof sequence not discharged."
+                );
+            }
+            if (unresolvedRules.has('AIP')) {
+                this.adderror(
+                    lastSubstantiveLine?.n || '1',
+                    "dependency",
+                    "low",
+                    "Indirect Proof sequence not discharged."
+                );
+            }
             this.adderror(
                 lastSubstantiveLine?.n || '1',
                 "completion",


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #5 

## 📝 Description

The derivation checker forces the conclusion to appear in the main proof scope, not inside an open ACP or AIP sequence.
- Added unresolved sequence feedback:
  - `Conditional Proof sequence not discharged.`
  - `Indirect Proof sequence not discharged.`
- Updated frontend derivation gating so line creation and completion status do not stop early when the conclusion is reached inside an open ACP or AIP sequence 

## 🚀 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🛠️ Refactor / Chore (Code cleanup, dependency update, etc.)

## 🧪 How to Test
1. Pull down this branch and run `npm run dev`
2. Navigate to any derivation question
3. Start a derivation with ACP or AIP
4. Check for a warning message
5.  Derive the target conclusion inside that open sequence
6. Do not discharge/use CP or IP
7. Verify that a warning appears:
   - `Conditional Proof sequence not discharged.` or
   - `Indirect Proof sequence not discharged.`
8. Verify that the answer is marked incorrect
9. Then properly discharge the sequence with CP or IP
10. Verify that the warning clears and the completed proof can be marked correct

  Example:
  - Premise: `A ⊃ P`
  - Conclusion: `(A • B) ⊃ (P ∨ Q)`
  
  Entered derivation:
  
  1. `A ⊃ P`
  2. `A • B` ACP
  3. `A` 2 Simp
  4. `P` 1,3 MP
  9. `P ∨ Q` 4 Add
  12. `(A • B) ⊃ (P ∨ Q)` ACP

The answer should be marked incorrect until the open ACP or AIP is properly discharged with CP or IP. While the ACP sequence is open, the checker should issue a warning. 

## ✅ Pre-Merge Checklist

- [x] I have performed a self-review of my own code.
- [x] I have removed all temporary `console.log`s and debuggers.
- [x] I have successfully rebased / resolved any merge conflicts with `main`.
- [x] UI looks good on both desktop and mobile viewports.
