### PR TITLE
restrict assignment reads to enrolled users

### DIFF
--- a/__tests__/course-assignment-auth.test.js
+++ b/__tests__/course-assignment-auth.test.js
@@ -6,21 +6,26 @@ const courseCreate = jest.fn();
 const courseEnrollmentFindOne = jest.fn();
 const assignmentFindByPk = jest.fn();
 const assignmentCreate = jest.fn();
+const assignmentQuestionFindAll = jest.fn();
 const assignmentDraftFindOne = jest.fn();
+const submissionFindAll = jest.fn();
 const requireInstructorOrAdmin = jest.fn();
+const sequelizeFn = jest.fn((name, value) => ({ name, value }));
+const sequelizeCol = jest.fn((value) => value);
 
 jest.unstable_mockModule('../models/index.js', () => ({
   Course: { findByPk: courseFindByPk, create: courseCreate },
   Assignment: { findByPk: assignmentFindByPk, create: assignmentCreate },
   AssignmentDraft: { findOne: assignmentDraftFindOne },
-  AssignmentExtension: {},
+  AssignmentExtension: { findOne: jest.fn() },
   AssignmentGrade: {},
-  AssignmentQuestion: {},
-  AssignmentQuestionOverride: {},
-  Accommodation: {},
+  AssignmentQuestion: { findAll: assignmentQuestionFindAll },
+  AssignmentQuestionOverride: { findAll: jest.fn() },
+  Accommodation: { findOne: jest.fn() },
   CourseEnrollment: { findOne: courseEnrollmentFindOne },
-  Submission: {},
+  Submission: { findAll: submissionFindAll },
   User: {},
+  sequelize: { fn: sequelizeFn, col: sequelizeCol },
 }));
 
 jest.unstable_mockModule('../routes/instructor.js', () => ({
@@ -91,8 +96,12 @@ describe('course and assignment auth', () => {
     courseEnrollmentFindOne.mockReset();
     assignmentFindByPk.mockReset();
     assignmentCreate.mockReset();
+    assignmentQuestionFindAll.mockReset();
     assignmentDraftFindOne.mockReset();
+    submissionFindAll.mockReset();
     requireInstructorOrAdmin.mockReset();
+    sequelizeFn.mockClear();
+    sequelizeCol.mockClear();
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 
@@ -173,6 +182,63 @@ describe('course and assignment auth', () => {
 
       expect(res.statusCode).toBe(403);
       expect(update).not.toHaveBeenCalled();
+    });
+
+    it('rejects assignment list reads for non-admins', async () => {
+      const handlers = getRouteHandlers(assignmentsRouter, '/', 'get');
+      const req = { user: { id: 7, is_system_admin: false } };
+      const res = await runHandlers(handlers, req, createRes());
+
+      expect(res.statusCode).toBe(403);
+    });
+
+    it('rejects assignment reads for users outside the course', async () => {
+      assignmentFindByPk.mockResolvedValueOnce({ id: 9, course_id: 3, kind: 'assignment' });
+      requireInstructorOrAdmin.mockResolvedValueOnce(false);
+      courseEnrollmentFindOne.mockResolvedValueOnce(null);
+
+      const handlers = getRouteHandlers(assignmentsRouter, '/:id', 'get');
+      const req = { params: { id: '9' }, query: {}, user: { id: 7, is_system_admin: false } };
+      const res = await runHandlers(handlers, req, createRes());
+
+      expect(res.statusCode).toBe(403);
+      expect(res.body).toEqual({ message: 'Enrollment required' });
+    });
+
+    it('strips answers from question payloads for enrolled students', async () => {
+      assignmentFindByPk.mockResolvedValueOnce({ id: 9, course_id: 3, kind: 'assignment' });
+      requireInstructorOrAdmin.mockResolvedValueOnce(false);
+      courseEnrollmentFindOne.mockResolvedValueOnce({ id: 14, role: 'student' });
+      assignmentQuestionFindAll.mockResolvedValueOnce([
+        {
+          toJSON: () => ({
+            id: 21,
+            assignment_id: 9,
+            attempt_limit: 3,
+            question_snapshot: {
+              prompt: 'Translate this.',
+              answer: 'P',
+              answerIndex: 1,
+            },
+          }),
+        },
+      ]);
+
+      const handlers = getRouteHandlers(assignmentsRouter, '/:id/questions', 'get');
+      const req = { params: { id: '9' }, query: {}, user: { id: 7, is_system_admin: false } };
+      const res = await runHandlers(handlers, req, createRes());
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual([
+        {
+          id: 21,
+          assignment_id: 9,
+          attempt_limit: 3,
+          question_snapshot: {
+            prompt: 'Translate this.',
+          },
+        },
+      ]);
     });
   });
 });

--- a/__tests__/derivation-hurley.test.js
+++ b/__tests__/derivation-hurley.test.js
@@ -1,0 +1,159 @@
+import checkDerivation from '../lib/logicpenguin/checkers/derivation-hurley.js';
+
+function buildProof({ conclusion, lines, premises = [] }) {
+  return {
+    parts: [
+      {
+        showline: { s: conclusion, j: '', isMainConclusion: true, n: '' },
+        parts: lines.map((line, index) => ({
+          n: String(index + 1),
+          s: line.formula,
+          j: line.justification ?? '',
+        })),
+      },
+    ],
+    prems: premises,
+    conc: conclusion,
+  };
+}
+
+async function runDerivation({ premises = [], conclusion, lines }) {
+  return checkDerivation(
+    { prems: premises, conc: conclusion },
+    null,
+    buildProof({ conclusion, lines, premises }),
+    false,
+    1,
+    false,
+    {}
+  );
+}
+
+function collectMessages(errors = {}) {
+  const messages = [];
+  for (const categories of Object.values(errors)) {
+    for (const severities of Object.values(categories || {})) {
+      for (const items of Object.values(severities || {})) {
+        messages.push(...Object.keys(items || {}));
+      }
+    }
+  }
+  return messages;
+}
+
+describe('derivation-hurley ACP/AIP completion', () => {
+  // this one catches the old bug where an open acp could still look complete
+  it('rejects a conclusion that appears only inside an unresolved ACP', async () => {
+    const result = await runDerivation({
+      conclusion: 'A',
+      lines: [
+        { formula: 'A', justification: 'ACP' },
+      ],
+    });
+
+    expect(result.successstatus).toBe('incorrect');
+    expect(collectMessages(result.errors)).toEqual(
+      expect.arrayContaining([
+        'Conditional Proof sequence not discharged.',
+        'open ACP/AIP subderivations must be closed with CP/IP before the proof is complete',
+        'final conclusion of argument not shown',
+      ])
+    );
+  });
+
+  // same bug but for indirect proof assumptions
+  it('rejects a conclusion that appears only inside an unresolved AIP', async () => {
+    const result = await runDerivation({
+      conclusion: 'A',
+      lines: [
+        { formula: 'A', justification: 'AIP' },
+      ],
+    });
+
+    expect(result.successstatus).toBe('incorrect');
+    expect(collectMessages(result.errors)).toEqual(
+      expect.arrayContaining([
+        'Indirect Proof sequence not discharged.',
+        'open ACP/AIP subderivations must be closed with CP/IP before the proof is complete',
+        'final conclusion of argument not shown',
+      ])
+    );
+  });
+
+  // even if the conclusion showed up earlier the proof stays open until cp or ip closes it
+  it('rejects a proof with an unresolved ACP after a main-scope conclusion is shown', async () => {
+    const result = await runDerivation({
+      premises: ['A'],
+      conclusion: 'A',
+      lines: [
+        { formula: 'A', justification: 'Pr' },
+        { formula: 'B', justification: 'ACP' },
+      ],
+    });
+
+    expect(result.successstatus).toBe('incorrect');
+    expect(collectMessages(result.errors)).toEqual(
+      expect.arrayContaining([
+        'Conditional Proof sequence not discharged.',
+        'open ACP/AIP subderivations must be closed with CP/IP before the proof is complete',
+      ])
+    );
+  });
+
+  // old false positive where the target formula appeared on an acp line
+  it('rejects a conditional proof target that is entered as ACP instead of CP', async () => {
+    const result = await runDerivation({
+      premises: ['A⊃P'],
+      conclusion: '(A•B)⊃(P∨Q)',
+      lines: [
+        { formula: 'A⊃P', justification: 'Pr' },
+        { formula: 'A•B', justification: 'ACP' },
+        { formula: 'A', justification: '2 Simp' },
+        { formula: 'P', justification: '1,3 MP' },
+        { formula: 'P∨Q', justification: '4 Add' },
+        { formula: '(A•B)⊃(P∨Q)', justification: 'ACP' },
+      ],
+    });
+
+    expect(result.successstatus).toBe('incorrect');
+    expect(collectMessages(result.errors)).toEqual(
+      expect.arrayContaining([
+        'Conditional Proof sequence not discharged.',
+        'open ACP/AIP subderivations must be closed with CP/IP before the proof is complete',
+        'final conclusion of argument not shown',
+      ])
+    );
+  });
+
+  // this is the path that should still pass
+  it('accepts a properly discharged ACP/CP derivation', async () => {
+    const result = await runDerivation({
+      premises: ['A'],
+      conclusion: 'B⊃A',
+      lines: [
+        { formula: 'A', justification: 'Pr' },
+        { formula: 'B', justification: 'ACP' },
+        { formula: 'A', justification: '' },
+        { formula: 'B⊃A', justification: '2-3 CP' },
+      ],
+    });
+
+    expect(result.successstatus).toBe('correct');
+  });
+
+  // and this is the matching indirect proof path
+  it('accepts a properly discharged AIP/IP derivation', async () => {
+    const result = await runDerivation({
+      premises: ['A•~A'],
+      conclusion: '~B',
+      lines: [
+        { formula: 'A•~A', justification: 'Pr' },
+        { formula: 'B', justification: 'AIP' },
+        { formula: 'A•~A', justification: '' },
+        { formula: '~B', justification: '2-3 IP' },
+      ],
+    });
+
+    expect(result.successstatus).toBe('correct');
+  });
+});

--- a/routes/assignments.js
+++ b/routes/assignments.js
@@ -8,6 +8,7 @@ import {
   AssignmentQuestionOverride,
   Accommodation,
   AssignmentGrade,
+  CourseEnrollment,
   Submission,
   User,
   sequelize,
@@ -39,6 +40,56 @@ function formatPolicyDates(policy) {
   };
 }
 
+function stripQuestionAnswers(snapshot) {
+  if (!snapshot || typeof snapshot !== 'object' || Array.isArray(snapshot)) {
+    return snapshot;
+  }
+  if (
+    !Object.prototype.hasOwnProperty.call(snapshot, 'answer')
+    && !Object.prototype.hasOwnProperty.call(snapshot, 'answerIndex')
+  ) {
+    return snapshot;
+  }
+  const sanitized = { ...snapshot };
+  delete sanitized.answer;
+  delete sanitized.answerIndex;
+  return sanitized;
+}
+
+function sanitizeQuestionForUser(question, { canSeeAnswers, attemptCount = 0, alwaysHideAnswers = false }) {
+  const data = question.toJSON ? question.toJSON() : { ...question };
+  if (canSeeAnswers) {
+    return data;
+  }
+  if (alwaysHideAnswers || attemptCount < data.attempt_limit) {
+    data.question_snapshot = stripQuestionAnswers(data.question_snapshot);
+  }
+  return data;
+}
+
+async function getAssignmentReadAccess(assignment, user) {
+  if (!assignment || !user?.id) {
+    return { allowed: false, canSeeAnswers: false };
+  }
+  const canSeeAnswers = await requireInstructorOrAdmin(assignment.course_id, user.id);
+  if (canSeeAnswers) {
+    return { allowed: true, canSeeAnswers: true };
+  }
+  const enrollment = await CourseEnrollment.findOne({
+    where: { course_id: assignment.course_id, user_id: user.id },
+  });
+  return { allowed: Boolean(enrollment), canSeeAnswers: false };
+}
+
+async function requireAssignmentReadAccess(req, res, assignment) {
+  const access = await getAssignmentReadAccess(assignment, req.user);
+  if (!access.allowed) {
+    res.status(403).json({ message: 'Enrollment required' });
+    return null;
+  }
+  return access;
+}
+
 const router = createCrudRouter(Assignment, {
   disableGetById: true,
   sanitize: sanitizeAssignment,
@@ -57,9 +108,11 @@ const router = createCrudRouter(Assignment, {
     }
     return requireInstructorOrAdmin(courseId, req.user.id);
   },
-  authorizeRecord: (req, record, action) => {
+  authorizeList: (req) => isSystemAdmin(req.user),
+  authorizeRecord: async (req, record, action) => {
     if (action === 'read') {
-      return true;
+      const access = await getAssignmentReadAccess(record, req.user);
+      return access.allowed;
     }
     return requireInstructorOrAdmin(record.course_id, req.user.id);
   },
@@ -70,6 +123,10 @@ router.get('/:id', [assignmentIdParam, userIdOptionalQuery, handleValidationResu
     const assignment = await Assignment.findByPk(req.params.id);
     if (!assignment) {
       return res.status(404).json({ message: 'Not found' });
+    }
+    const access = await requireAssignmentReadAccess(req, res, assignment);
+    if (!access) {
+      return;
     }
 
     const requestedUserId = req.query.userId;
@@ -133,7 +190,7 @@ router.get('/:id', [assignmentIdParam, userIdOptionalQuery, handleValidationResu
     }
 
     const userIdForFiltering = requestedUserId || req.user?.id;
-    const canSeeAnswers = await requireInstructorOrAdmin(assignment.course_id, req.user.id);
+    const { canSeeAnswers } = access;
     if (!canSeeAnswers && userIdForFiltering && questionsWithLimits.length) {
       const questionIds = questionsWithLimits.map((question) => question.id);
       const attemptCounts = await Submission.findAll({
@@ -149,23 +206,8 @@ router.get('/:id', [assignmentIdParam, userIdOptionalQuery, handleValidationResu
         attemptCounts.map((row) => [row.assignment_question_id, Number(row.attempt_count)])
       );
       questionsWithLimits = questionsWithLimits.map((question) => {
-        const data = question.toJSON ? question.toJSON() : { ...question };
-        const attemptCount = attemptCountMap.get(data.id) ?? 0;
-        if (attemptCount < data.attempt_limit) {
-          const snapshot = data.question_snapshot;
-          if (snapshot && typeof snapshot === 'object' && !Array.isArray(snapshot)) {
-            if (
-              Object.prototype.hasOwnProperty.call(snapshot, 'answer')
-              || Object.prototype.hasOwnProperty.call(snapshot, 'answerIndex')
-            ) {
-              const sanitized = { ...snapshot };
-              delete sanitized.answer;
-              delete sanitized.answerIndex;
-              data.question_snapshot = sanitized;
-            }
-          }
-        }
-        return data;
+        const attemptCount = attemptCountMap.get(question.id) ?? 0;
+        return sanitizeQuestionForUser(question, { canSeeAnswers, attemptCount });
       });
     }
 
@@ -179,11 +221,25 @@ router.get('/:id', [assignmentIdParam, userIdOptionalQuery, handleValidationResu
 
 router.get('/:id/questions', [assignmentIdParam, handleValidationResult], async (req, res, next) => {
   try {
+    const assignment = await Assignment.findByPk(req.params.id);
+    if (!assignment) {
+      return res.status(404).json({ message: 'Not found' });
+    }
+    const access = await requireAssignmentReadAccess(req, res, assignment);
+    if (!access) {
+      return;
+    }
     const questions = await AssignmentQuestion.findAll({
       where: { assignment_id: req.params.id },
       order: [['order_index', 'ASC']],
     });
-    res.json(questions);
+    const payload = access.canSeeAnswers
+      ? questions
+      : questions.map((question) => sanitizeQuestionForUser(question, {
+        canSeeAnswers: false,
+        alwaysHideAnswers: true,
+      }));
+    res.json(payload);
   } catch (error) {
     next(error);
   }
@@ -207,6 +263,14 @@ router.get('/:id/grades', [assignmentIdParam, handleValidationResult], async (re
 
 router.get('/:id/submissions', [assignmentIdParam, userIdOptionalQuery, handleValidationResult], async (req, res, next) => {
   try {
+    const assignment = await Assignment.findByPk(req.params.id);
+    if (!assignment) {
+      return res.status(404).json({ message: 'Not found' });
+    }
+    const access = await requireAssignmentReadAccess(req, res, assignment);
+    if (!access) {
+      return;
+    }
     const requestedUserId = req.query.userId;
     if (requestedUserId && !ensureSelfOrAdmin(req, res, requestedUserId)) {
       return;


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #7 

## 📝 Description

I patched an auth gap by requiring enrollment before returning assignment resources, locking down assignment list reads, and stripping `answer` and `answerIndex` from question payloads sent to students.

## 🚀 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🛠️ Refactor / Chore (Code cleanup, dependency update, etc.)

## 🧪 How to Test

[Provide clear steps for the reviewer to manually test your UI or API changes.]

1. Pull down this branch and run `npm test -- __tests__/course-assignment-auth.test.js`
2. Request `GET /api/assignments/:id` for an assignment in a course the current user is not enrolled in
3. Verify that the API returns `403` with `Enrollment required`
4. Request `GET /api/assignments/:id/questions` as an enrolled student
5. Verify no `answer` and ` answerIndex` in the response payload

6. Request the same endpoint as an instructor or admin
7. Confirm that the full question payload is still returned

## ✅ Pre-Merge Checklist

- [x] I have performed a self-review of my own code.
- [x] I have removed all temporary `console.log`s and debuggers.
- [x] I have successfully rebased / resolved any merge conflicts with `main`.
- [x] UI looks good on both desktop and mobile viewports.
