### PR TITLE
add csrf origin checks

### DIFF
--- a/__tests__/csrf.test.js
+++ b/__tests__/csrf.test.js
@@ -1,0 +1,99 @@
+import { jest } from '@jest/globals';
+import { createCsrfProtection, parseAllowedOrigins } from '../middleware/csrf.js';
+
+const createReq = ({ method = 'POST', headers = {} } = {}) => ({
+  method,
+  get(name) {
+    return headers[String(name).toLowerCase()] ?? headers[name] ?? undefined;
+  },
+});
+
+const createRes = () => ({
+  statusCode: 200,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+describe('csrf protection', () => {
+  it('parses configured origins consistently', () => {
+    expect(parseAllowedOrigins(' https://app.example.com/, http://localhost:5173 ')).toEqual([
+      'https://app.example.com',
+      'http://localhost:5173',
+    ]);
+  });
+
+  it('allows safe methods without origin headers', () => {
+    const middleware = createCsrfProtection(['https://app.example.com']);
+    const req = createReq({ method: 'GET' });
+    const res = createRes();
+    const next = jest.fn();
+
+    middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('allows unsafe requests from an allowed origin', () => {
+    const middleware = createCsrfProtection(['https://app.example.com']);
+    const req = createReq({
+      headers: { origin: 'https://app.example.com' },
+    });
+    const res = createRes();
+    const next = jest.fn();
+
+    middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('allows unsafe requests from an allowed referer origin', () => {
+    const middleware = createCsrfProtection(['https://app.example.com']);
+    const req = createReq({
+      headers: { referer: 'https://app.example.com/dashboard?tab=1' },
+    });
+    const res = createRes();
+    const next = jest.fn();
+
+    middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('rejects unsafe requests from a disallowed origin', () => {
+    const middleware = createCsrfProtection(['https://app.example.com']);
+    const req = createReq({
+      headers: { origin: 'https://evil.example.com' },
+    });
+    const res = createRes();
+    const next = jest.fn();
+
+    middleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({ message: 'Invalid request origin' });
+  });
+
+  it('rejects unsafe requests without origin metadata', () => {
+    const middleware = createCsrfProtection(['https://app.example.com']);
+    const req = createReq();
+    const res = createRes();
+    const next = jest.fn();
+
+    middleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({ message: 'Invalid request origin' });
+  });
+});

--- a/middleware/csrf.js
+++ b/middleware/csrf.js
@@ -1,0 +1,51 @@
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+function normalizeOrigin(origin) {
+  return typeof origin === 'string' ? origin.trim().replace(/\/$/, '') : '';
+}
+
+function parseAllowedOrigins(rawOrigins) {
+  return String(rawOrigins || '')
+    .split(',')
+    .map((origin) => normalizeOrigin(origin))
+    .filter(Boolean);
+}
+
+function getRequestOrigin(req) {
+  const originHeader = normalizeOrigin(req.get('origin'));
+  if (originHeader) {
+    return originHeader;
+  }
+
+  const refererHeader = req.get('referer');
+  if (!refererHeader) {
+    return '';
+  }
+
+  try {
+    // fall back to referer when origin is missing
+    return normalizeOrigin(new URL(refererHeader).origin);
+  } catch {
+    return '';
+  }
+}
+
+export function createCsrfProtection(allowedOrigins) {
+  const normalizedAllowedOrigins = allowedOrigins.map((origin) => normalizeOrigin(origin));
+
+  return function csrfProtection(req, res, next) {
+    if (SAFE_METHODS.has(req.method)) {
+      return next();
+    }
+
+    // block unsafe requests unless they come from a trusted origin
+    const requestOrigin = getRequestOrigin(req);
+    if (requestOrigin && normalizedAllowedOrigins.includes(requestOrigin)) {
+      return next();
+    }
+
+    return res.status(403).json({ message: 'Invalid request origin' });
+  };
+}
+
+export { getRequestOrigin, parseAllowedOrigins };

--- a/server.js
+++ b/server.js
@@ -19,6 +19,7 @@ import analyticsRouter from './routes/analytics.js';
 import validateRouter from './routes/validate.js';
 import instructorRouter from './routes/instructor.js';
 import requireAuth from './middleware/auth.js';
+import { createCsrfProtection, parseAllowedOrigins } from './middleware/csrf.js';
 import errorHandler from './middleware/error-handler.js';
 import { scheduleAutoSubmitSweep } from './jobs/autoSubmit.js';
 
@@ -27,7 +28,8 @@ dotenv.config();
 const app = express();
 const PORT = process.env.PORT || 3000;
 const rawOrigins = process.env.CORS_ORIGIN || process.env.FRONTEND_ORIGIN || 'https://hunterlogic.vercel.app';
-const allowedOrigins = rawOrigins.split(',').map((origin) => origin.trim()).filter(Boolean);
+const allowedOrigins = parseAllowedOrigins(rawOrigins);
+const csrfProtection = createCsrfProtection(allowedOrigins);
 
 app.use(cors({
   origin: (origin, callback) => {
@@ -47,6 +49,8 @@ app.get('/health', (req, res) => {
   res.json({ status: 'ok', message: 'Server is running' });
 });
 
+// check origin before auth on unsafe api requests
+app.use('/api', csrfProtection);
 app.use('/api/auth', authRouter);
 app.use('/api', (req, res, next) => {
   // let login through without a jwt


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #[Insert issue number here - e.g., Closes #12]

## 📝 Description

Adds origin-based CSRF protection for unsafe backend API requests. This blocks cookie-authenticated cross-site POST/PUT/DELETE traffic unless the request comes from an allowed frontend origin, and adds tests for the middleware behavior.

## 🚀 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🛠️ Refactor / Chore (Code cleanup, dependency update, etc.)

## 🧪 How to Test

[Provide clear steps for the reviewer to manually test your UI or API changes.]

1. Pull down this branch and run `npm run dev`
2. Run npm test -- --runInBand __tests__/csrf.test.js __tests__/course-assignment-auth.test.js in backend/
3. See if you can send an unsafe API request from a frontend origin 
4. Confirm a 403 is thrown when you send the same request with a missing Origin

## ✅ Pre-Merge Checklist

- [x] I have performed a self-review of my own code.
- [x] I have removed all temporary `console.log`s and debuggers.
- [x] I have successfully rebased / resolved any merge conflicts with `main`.
- [x] UI looks good on both desktop and mobile viewports.
