### PR TITLE
[BUGFIX] average calculated by only past-due assignments

### DIFF
--- a/__tests__/analytics.test.js
+++ b/__tests__/analytics.test.js
@@ -23,4 +23,86 @@ describe('computeGradebookStudents', () => {
     expect(student.dropped.average_percent).toBeCloseTo(0.825, 6);
     expect(student.dropped.drop_lowest_n).toBe(1);
   });
+
+  it('only includes past-due assignments in totals and drop logic', () => {
+    // future assignments should not affect past due averages
+    const past = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    const future = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+    const assignments = [
+      { id: 1, title: 'Past A1', total_points: 100, due_date: past },
+      { id: 2, title: 'Past A2', total_points: 100, due_date: past },
+      { id: 3, title: 'Future A3', total_points: 100, due_date: future },
+    ];
+    const enrollments = [
+      { user_id: 1, User: { id: 1, username: 'student1' } },
+    ];
+    const grades = [
+      { user_id: 1, assignment_id: 1, final_score: 80, max_score: 100 },
+      { user_id: 1, assignment_id: 2, final_score: 100, max_score: 100 },
+      { user_id: 1, assignment_id: 3, final_score: 0, max_score: 100 },
+    ];
+
+    const [student] = computeGradebookStudents(assignments, enrollments, grades, 1);
+
+    // only past due assignments should count in totals and drop lowest
+    expect(student.totals.average_percent).toBeCloseTo(0.9, 6);
+    expect(student.dropped.average_percent).toBeCloseTo(1.0, 6);
+    expect(student.dropped.drop_lowest_n).toBe(1);
+  });
+
+  it('returns null averages when there are no past-due assignments', () => {
+    // no past due assignments should have null averages
+    const future = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+    const assignments = [
+      { id: 1, title: 'Future A1', total_points: 100, due_date: future },
+      { id: 2, title: 'Future A2', total_points: 100, due_date: future },
+    ];
+    const enrollments = [
+      { user_id: 1, User: { id: 1, username: 'student1' } },
+    ];
+    const grades = [
+      { user_id: 1, assignment_id: 1, final_score: 100, max_score: 100 },
+    ];
+
+    const [student] = computeGradebookStudents(assignments, enrollments, grades, 1);
+
+    expect(student.totals.average_percent).toBeNull();
+    expect(student.dropped.average_percent).toBeNull();
+  });
+
+  it('treats missing past-due grades as zero in totals', () => {
+    // missing grades should count as zero once past due
+    const past = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    const assignments = [
+      { id: 1, title: 'Past A1', total_points: 100, due_date: past },
+      { id: 2, title: 'Past A2', total_points: 100, due_date: past },
+    ];
+    const enrollments = [
+      { user_id: 1, User: { id: 1, username: 'student1' } },
+    ];
+    const grades = [];
+
+    const [student] = computeGradebookStudents(assignments, enrollments, grades, 0);
+
+    expect(student.totals.average_percent).toBe(0);
+    expect(student.dropped.average_percent).toBe(0);
+  });
+
+  it('ignores assignments without due dates for past-due totals', () => {
+    // no due date should not count toward past due totals
+    const assignments = [
+      { id: 1, title: 'No Due A1', total_points: 100, due_date: null },
+    ];
+    const enrollments = [
+      { user_id: 1, User: { id: 1, username: 'student1' } },
+    ];
+    const grades = [
+      { user_id: 1, assignment_id: 1, final_score: 100, max_score: 100 },
+    ];
+
+    const [student] = computeGradebookStudents(assignments, enrollments, grades, 0);
+
+    expect(student.totals.average_percent).toBeNull();
+    expect(student.dropped.average_percent).toBeNull();
+  });
 });

--- a/__tests__/analytics.test.js
+++ b/__tests__/analytics.test.js
@@ -2,10 +2,11 @@ import { computeGradebookStudents } from '../routes/analytics.js';
 
 describe('computeGradebookStudents', () => {
   it('drops the lowest assignment by percent', () => {
+    const past = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
     const assignments = [
-      { id: 1, title: 'A1', total_points: 100 },
-      { id: 2, title: 'A2', total_points: 100 },
-      { id: 3, title: 'A3', total_points: 100 },
+      { id: 1, title: 'A1', total_points: 100, due_date: past },
+      { id: 2, title: 'A2', total_points: 100, due_date: past },
+      { id: 3, title: 'A3', total_points: 100, due_date: past },
     ];
     const enrollments = [
       { user_id: 1, User: { id: 1, username: 'student1' } },

--- a/__tests__/analyticsClassAvg.test.js
+++ b/__tests__/analyticsClassAvg.test.js
@@ -1,0 +1,116 @@
+import { jest } from '@jest/globals';
+
+const CourseEnrollment = { findAll: jest.fn() };
+const AssignmentGrade = { findAll: jest.fn() };
+const AssignmentExtension = { findAll: jest.fn() };
+const Accommodation = { findAll: jest.fn() };
+
+jest.unstable_mockModule('../models/index.js', () => ({
+  CourseEnrollment,
+  AssignmentGrade,
+  AssignmentExtension,
+  Accommodation,
+}));
+
+const { computeClassAvgWithDrop, effectiveGradesForGradebook } = await import(
+  '../routes/analytics.js'
+);
+
+describe('analytics helpers', () => {
+  beforeEach(() => {
+    CourseEnrollment.findAll.mockReset();
+    AssignmentGrade.findAll.mockReset();
+    AssignmentExtension.findAll.mockReset();
+    Accommodation.findAll.mockReset();
+  });
+
+  it('includes students with all missing past-due work as zero in class average', async () => {
+    // class avg should include students with all missing past due work as zero
+    const past = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    const rows = [
+      { id: 1, is_locked: false, due_date: past, avg_percent: 1 },
+      { id: 2, is_locked: false, due_date: past, avg_percent: 1 },
+      { id: 3, is_locked: false, due_date: past, avg_percent: 1 },
+    ];
+
+    CourseEnrollment.findAll.mockResolvedValueOnce([
+      { user_id: 1 },
+      { user_id: 2 },
+    ]);
+    AssignmentGrade.findAll.mockResolvedValueOnce([
+      { user_id: 1, assignment_id: 1, final_score: 100, max_score: 100 },
+      { user_id: 1, assignment_id: 2, final_score: 100, max_score: 100 },
+      { user_id: 1, assignment_id: 3, final_score: 100, max_score: 100 },
+    ]);
+
+    const avg = await computeClassAvgWithDrop(1, rows);
+
+    expect(avg).toBeCloseTo(50, 6);
+  });
+
+  it('does not synthesize a zero before the effective due date', async () => {
+    // extension should delay synthetic zero creation
+    const past = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    const future = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+    const assignments = [
+      {
+        id: 1,
+        due_date: past,
+        total_points: 100,
+        late_window_days: 0,
+      },
+    ];
+    const enrollments = [{ user_id: 1 }];
+    const grades = [];
+
+    AssignmentExtension.findAll.mockResolvedValueOnce([
+      { assignment_id: 1, user_id: 1, extended_due_date: future },
+    ]);
+    Accommodation.findAll.mockResolvedValueOnce([]);
+
+    const result = await effectiveGradesForGradebook(
+      assignments,
+      enrollments,
+      grades,
+      1
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('synthesizes a zero after the effective due date', async () => {
+    // synthetic zero should appear after due date
+    const past = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    const future = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+    const assignments = [
+      {
+        id: 1,
+        due_date: future,
+        total_points: 100,
+        late_window_days: 0,
+      },
+    ];
+    const enrollments = [{ user_id: 1 }];
+    const grades = [];
+
+    AssignmentExtension.findAll.mockResolvedValueOnce([
+      { assignment_id: 1, user_id: 1, extended_due_date: past },
+    ]);
+    Accommodation.findAll.mockResolvedValueOnce([]);
+
+    const result = await effectiveGradesForGradebook(
+      assignments,
+      enrollments,
+      grades,
+      1
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      user_id: 1,
+      assignment_id: 1,
+      final_score: 0,
+      max_score: 100,
+    });
+  });
+});

--- a/__tests__/analyticsClassAvg.test.js
+++ b/__tests__/analyticsClassAvg.test.js
@@ -4,12 +4,24 @@ const CourseEnrollment = { findAll: jest.fn() };
 const AssignmentGrade = { findAll: jest.fn() };
 const AssignmentExtension = { findAll: jest.fn() };
 const Accommodation = { findAll: jest.fn() };
+const Assignment = {};
+const AssignmentQuestion = {};
+const AssignmentQuestionOverride = {};
+const Submission = {};
+const User = {};
+const sequelize = {};
 
 jest.unstable_mockModule('../models/index.js', () => ({
   CourseEnrollment,
   AssignmentGrade,
   AssignmentExtension,
   Accommodation,
+  Assignment,
+  AssignmentQuestion,
+  AssignmentQuestionOverride,
+  Submission,
+  User,
+  sequelize,
 }));
 
 const { computeClassAvgWithDrop, effectiveGradesForGradebook } = await import(

--- a/__tests__/analyticsClassAvg.test.js
+++ b/__tests__/analyticsClassAvg.test.js
@@ -126,12 +126,14 @@ describe('analytics helpers', () => {
     });
   });
 
-  it('does not count past-due assignments before a student’s effective due date', async () => {
-    const past = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  it('rollup totals omit assignments not yet past the assignment due date', async () => {
+    // `computeGradebookStudents` past-due rollups use each assignment’s published due only
+    // (per-student extensions are applied in `effectiveGradesForGradebook`, not here).
+    const future = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
     const assignments = [
       {
         id: 1,
-        due_date: past,
+        due_date: future,
         total_points: 100,
         late_window_days: 0,
       },
@@ -148,7 +150,6 @@ describe('analytics helpers', () => {
       0
     );
 
-    // no past due work yet? totals should be empty
     expect(student.totals.total_points).toBe(0);
     expect(student.totals.average_percent).toBeNull();
   });

--- a/__tests__/analyticsClassAvg.test.js
+++ b/__tests__/analyticsClassAvg.test.js
@@ -24,7 +24,7 @@ jest.unstable_mockModule('../models/index.js', () => ({
   sequelize,
 }));
 
-const { computeClassAvgWithDrop, effectiveGradesForGradebook } = await import(
+const { computeClassAvgWithDrop, effectiveGradesForGradebook, computeGradebookStudents } = await import(
   '../routes/analytics.js'
 );
 
@@ -61,7 +61,7 @@ describe('analytics helpers', () => {
   });
 
   it('does not synthesize a zero before the effective due date', async () => {
-    // extension should delay synthetic zero creation
+    // extension delays synthetic zero creation until effective due date
     const past = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
     const future = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
     const assignments = [
@@ -91,7 +91,7 @@ describe('analytics helpers', () => {
   });
 
   it('synthesizes a zero after the effective due date', async () => {
-    // synthetic zero should appear after due date
+    // synthetic zero appears only after due date
     const past = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
     const future = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
     const assignments = [
@@ -124,5 +124,32 @@ describe('analytics helpers', () => {
       final_score: 0,
       max_score: 100,
     });
+  });
+
+  it('does not count past-due assignments before a student’s effective due date', async () => {
+    const past = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    const assignments = [
+      {
+        id: 1,
+        due_date: past,
+        total_points: 100,
+        late_window_days: 0,
+      },
+    ];
+    const enrollments = [
+      { user_id: 1, User: { id: 1, username: 'student1' }, role: 'student' },
+    ];
+
+    const effectiveGrades = [];
+    const [student] = computeGradebookStudents(
+      assignments,
+      enrollments,
+      effectiveGrades,
+      0
+    );
+
+    // no past due work yet? totals should be empty
+    expect(student.totals.total_points).toBe(0);
+    expect(student.totals.average_percent).toBeNull();
   });
 });

--- a/__tests__/analyticsQueries.test.js
+++ b/__tests__/analyticsQueries.test.js
@@ -1,6 +1,7 @@
 import { jest } from '@jest/globals';
 import {
   fetchAssignmentAnalytics,
+  fetchAssignmentGradeSummary,
   fetchStudentPerformance,
 } from '../queries/analytics.js';
 
@@ -29,5 +30,20 @@ describe('analytics queries', () => {
     await expect(fetchStudentPerformance(sequelize, 5, 2))
       .rejects
       .toThrow('failed to fetch student performance for user 5: db down');
+  });
+
+  it('fetchAssignmentGradeSummary accounts for missing grades as zero in averages', async () => {
+    // regression guard per assignment averages include missing past due work as zero
+    let capturedSql = '';
+    const sequelize = {
+      query: jest.fn().mockImplementation(async (sql) => {
+        capturedSql = sql;
+        return [[]];
+      }),
+    };
+
+    await fetchAssignmentGradeSummary(sequelize, 1);
+
+    expect(capturedSql).toMatch(/AVG\\(COALESCE\\(ag\\.final_score/i);
   });
 });

--- a/__tests__/instructor.routes.test.js
+++ b/__tests__/instructor.routes.test.js
@@ -26,6 +26,7 @@ jest.unstable_mockModule('../utils/passwords.js', () => ({
   verifyPassword: jest.fn(),
   PASSWORD_POLICY_MESSAGE:
     'Password must be at least 12 characters and include at least one uppercase letter, one lowercase letter, one number, and one symbol.',
+  isStrongPassword: jest.fn(() => true),
 }));
 
 const instructorRouter = (await import('../routes/instructor.js')).default;

--- a/__tests__/instructor.routes.test.js
+++ b/__tests__/instructor.routes.test.js
@@ -24,6 +24,8 @@ jest.unstable_mockModule('../models/index.js', () => ({
 jest.unstable_mockModule('../utils/passwords.js', () => ({
   hashPassword,
   verifyPassword: jest.fn(),
+  PASSWORD_POLICY_MESSAGE:
+    'Password must be at least 12 characters and include at least one uppercase letter, one lowercase letter, one number, and one symbol.',
 }));
 
 const instructorRouter = (await import('../routes/instructor.js')).default;

--- a/routes/analytics.js
+++ b/routes/analytics.js
@@ -309,15 +309,21 @@ router.get(
   }
 });
 
-// same policy as your grade: unlocked only, drop two lowest when three or more (not when two)
+// Past-due + unlocked only; drop two lowest when three or more (not when two)
 async function computeClassAvgWithDrop(courseId, rows) {
+  const now = new Date();
   const unlocked = (rows || []).filter((r) => r.is_locked === false);
-  const unlockedIds = unlocked.map((r) => r.id);
-  if (unlockedIds.length === 0) return null;
+  const unlockedPastDue = unlocked.filter((r) => {
+    const d = parseDueDate(r.due_at ?? r.due_date);
+    return d && now >= d;
+  });
+  const pool = unlockedPastDue;
+  const poolIds = pool.map((r) => r.id);
+  if (poolIds.length === 0) return null;
 
-  // with 1 or 2 unlocked there is no drop: use assignment-level avg_percent (same as before)
-  if (unlocked.length < 3) {
-    const vals = unlocked
+  // with 1 or 2 past-due unlocked there is no drop: use assignment-level avg_percent
+  if (pool.length < 3) {
+    const vals = pool
       .map((r) => r.avg_percent)
       .filter((v) => v != null && v !== undefined);
     if (vals.length === 0) return null;
@@ -333,7 +339,7 @@ async function computeClassAvgWithDrop(courseId, rows) {
 
   const grades = await AssignmentGrade.findAll({
     where: {
-      assignment_id: unlockedIds,
+      assignment_id: poolIds,
       user_id: studentIds,
     },
     attributes: ['user_id', 'assignment_id', 'final_score', 'max_score'],
@@ -350,12 +356,12 @@ async function computeClassAvgWithDrop(courseId, rows) {
   let count = 0;
   for (const e of enrollments) {
     const uid = e.user_id;
-    const percents = unlockedIds.map(
+    const percents = poolIds.map(
       (aid) => gradeByKey.get(`${uid}-${aid}`) ?? 0
     );
     const hasAnyGrade = percents.some((p) => p > 0);
     if (!hasAnyGrade) continue;
-    // percents only from unlocked assignments, dropped ones are always unlocked
+    // percents only from past-due unlocked pool (same ids as poolIds)
     const sorted = percents.slice().sort((a, b) => a - b);
     const afterDrop = sorted.slice(2);
     const studentAvg =
@@ -393,8 +399,8 @@ router.get('/gradebook-summary', [courseIdParam, handleValidationResult], async 
 });
 
 /**
- * Returns grades from DB plus synthetic 0 grades for (user, assignment) where
- * the student has no grade and either the assignment is unlocked or past cutoff.
+ * Returns grades from DB plus synthetic 0 rows for (user, assignment) with no grade
+ * once the student's effective due date has passed (extensions / accommodations included).
  * No DB writes.
  */
 async function effectiveGradesForGradebook(assignments, enrollments, grades, courseId) {
@@ -437,17 +443,17 @@ async function effectiveGradesForGradebook(assignments, enrollments, grades, cou
     for (const assignment of assignments) {
       if (hasGrade.has(`${userId}-${assignment.id}`)) continue;
 
-      const isUnlocked = assignment.is_locked === false;
-      let includeAsZero = isUnlocked;
-
-      if (!includeAsZero && assignment.due_date) {
+      let includeAsZero = false;
+      if (assignment.due_date) {
         const extension = extensionByKey.get(`${assignment.id}-${userId}`) ?? null;
         const policy = computeDeadlinePolicy({
           assignment: { due_date: assignment.due_date, late_window_days: assignment.late_window_days },
           extension,
           accommodation,
         });
-        includeAsZero = policy.cutoff_at != null && now > policy.cutoff_at;
+        // Synthetic 0 only after the student's effective due (extensions / accommodations),
+        // not merely because the assignment is unlocked and still upcoming.
+        includeAsZero = policy.due_at != null && now >= policy.due_at;
       }
 
       if (!includeAsZero) continue;
@@ -537,7 +543,34 @@ function buildAssignmentMeta(assignments) {
   }));
 }
 
+function gradeRowForUser(gradeMap, userId, assignment) {
+  const grade = gradeMap.get(userId)?.get(assignment.id) || null;
+  const maxScore = Number(grade?.max_score ?? assignment.total_points ?? 0);
+  const finalScore = Number(grade?.final_score ?? 0);
+  const percent = maxScore > 0 ? finalScore / maxScore : 0;
+  return {
+    assignment_id: assignment.id,
+    title: assignment.title,
+    final_score: finalScore,
+    max_score: maxScore,
+    percent,
+    has_grade: Boolean(grade),
+    has_submission: Boolean(grade?.id),
+  };
+}
+
 export function computeGradebookStudents(assignments, enrollments, grades, dropLowestN) {
+  const now = new Date();
+  const pastDueAssignments = (assignments || []).filter((assignment) => {
+    const raw =
+      assignment.due_date ??
+      assignment.get?.('due_date') ??
+      assignment.due_at ??
+      assignment.get?.('due_at');
+    const d = parseDueDate(raw);
+    return d && now >= d;
+  });
+
   const gradeMap = new Map();
   grades.forEach((grade) => {
     if (!gradeMap.has(grade.user_id)) {
@@ -548,31 +581,20 @@ export function computeGradebookStudents(assignments, enrollments, grades, dropL
 
   return enrollments.map((enrollment) => {
     const user = enrollment.User;
-    const perAssignment = assignments.map((assignment) => {
-      const grade = gradeMap.get(user.id)?.get(assignment.id) || null;
-      const maxScore = Number(
-        grade?.max_score ?? assignment.total_points ?? 0
-      );
-      const finalScore = Number(grade?.final_score ?? 0);
-      const percent = maxScore > 0 ? finalScore / maxScore : 0;
+    const perAssignment = assignments.map((assignment) =>
+      gradeRowForUser(gradeMap, user.id, assignment)
+    );
 
-      return {
-        assignment_id: assignment.id,
-        title: assignment.title,
-        final_score: finalScore,
-        max_score: maxScore,
-        percent,
-        has_grade: Boolean(grade),
-        has_submission: Boolean(grade?.id),
-      };
-    });
+    const perAssignmentPastDue = pastDueAssignments.map((assignment) =>
+      gradeRowForUser(gradeMap, user.id, assignment)
+    );
 
-    const totalScore = perAssignment.reduce((sum, item) => sum + item.final_score, 0);
-    const totalPoints = perAssignment.reduce((sum, item) => sum + item.max_score, 0);
+    const totalScore = perAssignmentPastDue.reduce((sum, item) => sum + item.final_score, 0);
+    const totalPoints = perAssignmentPastDue.reduce((sum, item) => sum + item.max_score, 0);
     const averagePercent = totalPoints > 0 ? totalScore / totalPoints : null;
 
-    const dropCount = Math.min(dropLowestN, perAssignment.length);
-    const remaining = perAssignment
+    const dropCount = Math.min(dropLowestN, perAssignmentPastDue.length);
+    const remaining = perAssignmentPastDue
       .slice()
       .sort((a, b) => a.percent - b.percent || a.assignment_id - b.assignment_id)
       .slice(dropCount);

--- a/routes/analytics.js
+++ b/routes/analytics.js
@@ -310,7 +310,7 @@ router.get(
 });
 
 // Past-due + unlocked only; drop two lowest when three or more (not when two)
-async function computeClassAvgWithDrop(courseId, rows) {
+export async function computeClassAvgWithDrop(courseId, rows) {
   const now = new Date();
   const unlocked = (rows || []).filter((r) => r.is_locked === false);
   const unlockedPastDue = unlocked.filter((r) => {
@@ -320,15 +320,6 @@ async function computeClassAvgWithDrop(courseId, rows) {
   const pool = unlockedPastDue;
   const poolIds = pool.map((r) => r.id);
   if (poolIds.length === 0) return null;
-
-  // with 1 or 2 past-due unlocked there is no drop: use assignment-level avg_percent
-  if (pool.length < 3) {
-    const vals = pool
-      .map((r) => r.avg_percent)
-      .filter((v) => v != null && v !== undefined);
-    if (vals.length === 0) return null;
-    return (vals.reduce((s, v) => s + v, 0) / vals.length) * 100;
-  }
 
   const enrollments = await CourseEnrollment.findAll({
     where: { course_id: courseId, role: 'student' },
@@ -359,11 +350,9 @@ async function computeClassAvgWithDrop(courseId, rows) {
     const percents = poolIds.map(
       (aid) => gradeByKey.get(`${uid}-${aid}`) ?? 0
     );
-    const hasAnyGrade = percents.some((p) => p > 0);
-    if (!hasAnyGrade) continue;
     // percents only from past-due unlocked pool (same ids as poolIds)
     const sorted = percents.slice().sort((a, b) => a - b);
-    const afterDrop = sorted.slice(2);
+    const afterDrop = poolIds.length >= 3 ? sorted.slice(2) : sorted;
     const studentAvg =
       afterDrop.length > 0
         ? afterDrop.reduce((s, p) => s + p, 0) / afterDrop.length
@@ -403,7 +392,7 @@ router.get('/gradebook-summary', [courseIdParam, handleValidationResult], async 
  * once the student's effective due date has passed (extensions / accommodations included).
  * No DB writes.
  */
-async function effectiveGradesForGradebook(assignments, enrollments, grades, courseId) {
+export async function effectiveGradesForGradebook(assignments, enrollments, grades, courseId) {
   const assignmentIds = assignments.map((a) => a.id);
   const userIds = enrollments.map((e) => e.user_id);
   if (!assignmentIds.length || !userIds.length) return grades;


### PR DESCRIPTION
## 📝 Description

This PR aligns the API gradebook and summary analytics with “average over past-due work only.”

Synthetic 0% rows are inserted only after a student’s effective due (base due plus extensions/accommodations from `computeDeadlinePolicy`), not simply because an assignment is unlocked.

Class average with drop (`computeClassAvgWithDrop`) and per-student totals / drop-lowest in `computeGradebookStudents` now consider unlocked assignments that are past due only; full per-assignment rows are unchanged for column display.

Past-due checks use `>=` the due instant for consistency with the client.

JSDoc on synthetic grades is updated, duplicate grade-row mapping is consolidated behind `gradeRowForUser`, and the analytics unit test assigns past `due_date` values so rollup behavior stays covered.

## 🚀 Type of Change

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🛠️ Refactor / Chore (Code cleanup, dependency update, etc.)

## 🧪 How to Test

Test with [frontend PR #29.](https://github.com/m-ades/frontend-logic/pull/29)

## ✅ Pre-Merge Checklist

- [X] I have performed a self-review of my own code.
- [X] I have removed all temporary `console.log`s and debuggers.
- [X] I have successfully rebased / resolved any merge conflicts with `main`.
- [X] UI looks good on both desktop and mobile viewports.
