### PR TITLE
ensure assignment_question_id exsists before question session insert

### DIFF
--- a/__tests__/question-sessions.routes.test.js
+++ b/__tests__/question-sessions.routes.test.js
@@ -1,0 +1,140 @@
+import { jest } from '@jest/globals';
+import errorHandler from '../middleware/error-handler.js';
+
+const create = jest.fn();
+const assignmentQuestionFindByPk = jest.fn();
+
+jest.unstable_mockModule('../models/index.js', () => ({
+  QuestionSession: { create },
+  AssignmentQuestion: { findByPk: assignmentQuestionFindByPk },
+}));
+
+jest.unstable_mockModule('../utils/authorization.js', () => ({
+  isSystemAdmin: (user) => Boolean(user?.is_system_admin),
+}));
+
+const questionSessionsRouter = (await import('../routes/question-sessions.js')).default;
+
+const getRouteHandlers = (path, method) => {
+  const layer = questionSessionsRouter.stack.find(
+    (entry) => entry.route?.path === path && entry.route.methods[method]
+  );
+  if (!layer) {
+    throw new Error(`route not found: ${method.toUpperCase()} ${path}`);
+  }
+  return layer.route.stack.map((entry) => entry.handle);
+};
+
+const createRes = () => ({
+  statusCode: 200,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+  end() {
+    return this;
+  },
+});
+
+const runHandlers = async (handlers, req, res) => {
+  let index = 0;
+  let error = null;
+
+  while (index < handlers.length && !error) {
+    const handler = handlers[index];
+    let nextCalled = false;
+
+    await handler(req, res, (err) => {
+      nextCalled = true;
+      if (err) {
+        error = err;
+      } else {
+        index += 1;
+      }
+    });
+
+    if (!nextCalled) {
+      break;
+    }
+  }
+
+  if (error) {
+    await errorHandler(error, req, res, () => {});
+  }
+
+  return res;
+};
+
+describe('question sessions routes', () => {
+  beforeEach(() => {
+    create.mockReset();
+    assignmentQuestionFindByPk.mockReset();
+  });
+
+  describe('POST /', () => {
+    it('returns 400 when assignment_question_id is missing', async () => {
+      const handlers = getRouteHandlers('/', 'post');
+      const req = { body: {}, user: { id: 42 } };
+      const res = await runHandlers(handlers, req, createRes());
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.message).toBe('assignment_question_id is required');
+      expect(create).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when assignment question does not exist', async () => {
+      assignmentQuestionFindByPk.mockResolvedValueOnce(null);
+
+      const handlers = getRouteHandlers('/', 'post');
+      const req = { body: { assignment_question_id: 999 }, user: { id: 42 } };
+      const res = await runHandlers(handlers, req, createRes());
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body.message).toBe('assignment_question_id not found');
+      expect(create).not.toHaveBeenCalled();
+    });
+
+    it('creates a session with current user id for non-admins', async () => {
+      assignmentQuestionFindByPk.mockResolvedValueOnce({ id: 10 });
+      create.mockResolvedValueOnce({ id: 1, assignment_question_id: 10, user_id: 42 });
+
+      const handlers = getRouteHandlers('/', 'post');
+      const req = {
+        body: { assignment_question_id: 10, user_id: 999, started_at: '2026-04-09T00:00:00Z' },
+        user: { id: 42, is_system_admin: false },
+      };
+      const res = await runHandlers(handlers, req, createRes());
+
+      expect(res.statusCode).toBe(201);
+      expect(create).toHaveBeenCalledWith({
+        assignment_question_id: 10,
+        user_id: 42,
+        started_at: '2026-04-09T00:00:00Z',
+      });
+    });
+
+    it('preserves payload user_id for system admins', async () => {
+      assignmentQuestionFindByPk.mockResolvedValueOnce({ id: 10 });
+      create.mockResolvedValueOnce({ id: 1, assignment_question_id: 10, user_id: 7 });
+
+      const handlers = getRouteHandlers('/', 'post');
+      const req = {
+        body: { assignment_question_id: 10, user_id: 7, started_at: '2026-04-09T00:00:00Z' },
+        user: { id: 1, is_system_admin: true },
+      };
+      const res = await runHandlers(handlers, req, createRes());
+
+      expect(res.statusCode).toBe(201);
+      expect(create).toHaveBeenCalledWith({
+        assignment_question_id: 10,
+        user_id: 7,
+        started_at: '2026-04-09T00:00:00Z',
+      });
+    });
+  });
+});

--- a/routes/question-sessions.js
+++ b/routes/question-sessions.js
@@ -1,5 +1,5 @@
 import { createCrudRouter } from './crud.js';
-import { QuestionSession } from '../models/index.js';
+import { AssignmentQuestion, QuestionSession } from '../models/index.js';
 import { isSystemAdmin } from '../utils/authorization.js';
 
 const router = createCrudRouter(QuestionSession, {
@@ -8,9 +8,23 @@ const router = createCrudRouter(QuestionSession, {
     isSystemAdmin(req.user) || Number(record.user_id) === Number(req.user?.id)
   ),
   authorizeCreate: (req) => Boolean(req.user),
-  beforeCreate: (req, payload) => (
-    isSystemAdmin(req.user) ? payload : { ...payload, user_id: req.user.id }
-  ),
+  beforeCreate: async (req, payload) => {
+    const assignmentQuestionId = Number(payload.assignment_question_id);
+    if (!assignmentQuestionId) {
+      const error = new Error('assignment_question_id is required');
+      error.status = 400;
+      throw error;
+    }
+
+    const assignmentQuestion = await AssignmentQuestion.findByPk(assignmentQuestionId);
+    if (!assignmentQuestion) {
+      const error = new Error('assignment_question_id not found');
+      error.status = 404;
+      throw error;
+    }
+
+    return isSystemAdmin(req.user) ? payload : { ...payload, user_id: req.user.id };
+  },
   beforeUpdate: (req, payload, record) => (
     isSystemAdmin(req.user) ? payload : { ...payload, user_id: record.user_id }
   ),


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #[Insert issue number here - e.g., Closes #12]

## 📝 Description

Add validation to the question sessions create route to ensure `assignment_question_id` exists before insert. 

## 🚀 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🛠️ Refactor / Chore (Code cleanup, dependency update, etc.)

## 🧪 How to Test

[Provide clear steps for the reviewer to manually test your UI or API changes.]

1. Pull down this branch and run `npm run dev`
2. POST to `/question-sessions` with a valid `assignment_question_id` and confirm a 201 response
3. POST to `/question-sessions` with a non-existent `assignment_question_id` and confirm a 404 response, not an FK error.

## ✅ Pre-Merge Checklist

- [x] I have performed a self-review of my own code.
- [x] I have removed all temporary `console.log`s and debuggers.
- [x] I have successfully rebased / resolved any merge conflicts with `main`.
- [x] UI looks good on both desktop and mobile viewports.
