### PR TITLE
dont reparse normalized aip target during ip validation

### DIFF
--- a/__tests__/derivation-hurley.test.js
+++ b/__tests__/derivation-hurley.test.js
@@ -1,4 +1,5 @@
 import checkDerivation from '../lib/logicpenguin/checkers/derivation-hurley.js';
+import getFormulaClass from '../lib/logicpenguin/symbolic/formula.js';
 
 function buildProof({ conclusion, lines, premises = [] }) {
   return {
@@ -42,6 +43,13 @@ function collectMessages(errors = {}) {
 }
 
 describe('derivation-hurley ACP/AIP completion', () => {
+  it('round trips normalized quantified conditionals inside negations', () => {
+    const Formula = getFormulaClass();
+    const formula = Formula.from('~~(∃xAx ⊃ ~Cbc)');
+
+    expect(formula.normal).toBe('~~(∃xAx ⊃ ~Cbc)');
+  });
+
   // this one catches the old bug where an open acp could still look complete
   it('rejects a conclusion that appears only inside an unresolved ACP', async () => {
     const result = await runDerivation({
@@ -175,6 +183,21 @@ describe('derivation-hurley ACP/AIP completion', () => {
         { formula: 'Bn • ~Bn', justification: '9, 10 Conj' },
         { formula: '~(∀x)~Bx', justification: '7-11 IP' },
         { formula: '(∃x)Bx', justification: '12 QN' },
+      ],
+    });
+
+    expect(result.successstatus).toBe('correct');
+  });
+
+  it('accepts IP over a negated quantified conditional AIP assumption', async () => {
+    const result = await runDerivation({
+      premises: ['A•~A'],
+      conclusion: '~~[(∃x)Ax ⊃ ~Cbc]',
+      lines: [
+        { formula: 'A•~A', justification: 'Pr' },
+        { formula: '~[(∃x)Ax ⊃ ~Cbc]', justification: 'AIP' },
+        { formula: 'A•~A', justification: '' },
+        { formula: '~~[(∃x)Ax ⊃ ~Cbc]', justification: '2-3 IP' },
       ],
     });
 

--- a/lib/logicpenguin/checkers/derivation-check.js
+++ b/lib/logicpenguin/checkers/derivation-check.js
@@ -762,10 +762,7 @@ export default class DerivationCheck {
         const assumptionNormal = assumptionFormula
             ? assumptionFormula.wrapifneeded()
             : (assumptionLine.formulaNormal ?? '').trim();
-        const expectedFormula = assumptionNormal
-            ? this.Formula.from(notSym + assumptionNormal)
-            : null;
-        const expected = expectedFormula?.normal ?? (notSym + assumptionNormal);
+        const expected = notSym + assumptionNormal;
         if (line.formulaNormal.trim() !== expected) {
             this.adderror(line.n, "rule", "high",
                 "IP conclusion must be the negation of the AIP assumption.");

--- a/lib/logicpenguin/symbolic/libsyntax.js
+++ b/lib/logicpenguin/symbolic/libsyntax.js
@@ -123,7 +123,7 @@ function inputfix(s) {
 function stripmatching(s) {
     if (s.length < 2) { return s; }
 
-    const qMatch = s.match(/^\(?[∃∀][x-z]\)?/);
+    const qMatch = s.match(/^(?:[∃∀][x-z]|\([∃∀][x-z]\)|\([x-z]\))/);
     if (qMatch) { return s;}
     
     const openBrackets = { '(': ')', '[': ']', '{': '}' };


### PR DESCRIPTION
## 📝 Description

Fixes IP validation of an AIP line with a normalized form that contains quantified statements, such as `~[(∃x)Ax ⊃ ~Cbc]`, by making the checker avoid an unnecessary re-parse for IP validation.

## 🚀 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🛠️ Refactor / Chore (Code cleanup, dependency update, etc.)