### PR TITLE
allow UI conclusion constants & disallow them for EI

### DIFF
--- a/__tests__/derivation-hurley.test.js
+++ b/__tests__/derivation-hurley.test.js
@@ -219,3 +219,36 @@ describe('derivation-hurley quantifier negation rule names', () => {
     expect(result.successstatus).toBe('correct');
   });
 });
+
+describe('derivation-hurley quantifier constant restrictions', () => {
+  it('allows UI to introduce a constant from the argument conclusion', async () => {
+    const result = await runDerivation({
+      premises: ['∀xFx'],
+      conclusion: 'Fa',
+      lines: [
+        { formula: '∀xFx', justification: 'Pr' },
+        { formula: 'Fa', justification: '1 UI' },
+      ],
+    });
+
+    expect(result.successstatus).toBe('correct');
+  });
+
+  it('rejects EI when the introduced constant occurs in the argument conclusion', async () => {
+    const result = await runDerivation({
+      premises: ['∃xFx'],
+      conclusion: 'Fa',
+      lines: [
+        { formula: '∃xFx', justification: 'Pr' },
+        { formula: 'Fa', justification: '1 EI' },
+      ],
+    });
+
+    expect(result.successstatus).toBe('incorrect');
+    expect(collectMessages(result.errors)).toEqual(
+      expect.arrayContaining([
+        'does not use a new name as is required by EI',
+      ])
+    );
+  });
+});

--- a/lib/logicpenguin/checkers/derivation-check.js
+++ b/lib/logicpenguin/checkers/derivation-check.js
@@ -1755,7 +1755,6 @@ export class formFit {
                 checkpart = currsubderiv?.parts?.[currindex-1]?? false;
             } else {
                 if (currsubderiv?.showline &&
-                    !currsubderiv.showline.isMainConclusion &&
                     currsubderiv.showline != line) {
                     const f = Formula.from(currsubderiv.showline.s);
                     if (f.terms.indexOf(newname) !== -1) {
@@ -1773,7 +1772,7 @@ export class formFit {
             // if a subderiv, again check its showline,
             // which is available
             if (checkpart.parts) {
-                if (checkpart.showline && !checkpart.showline.isMainConclusion) {
+                if (checkpart.showline) {
                     const f = Formula.from(checkpart.showline.s);
                     if (f.terms.indexOf(newname) !== -1) {
                         return false;


### PR DESCRIPTION
## 📝 Description

Updates what constants can and cannot be used with UI and EI in the Hurley system.

- UI can now use constants from the conclusion in addition to constants from previous derivation lines.
- EI cannot use constants from the conclusion as new names.