### PR TITLE
Validation decoupling

### DIFF
--- a/__tests__/combo-translation-derivation.test.js
+++ b/__tests__/combo-translation-derivation.test.js
@@ -1,0 +1,102 @@
+import { validateLogicPenguin } from '../validators/logicpenguin.js';
+
+function buildFlatProof({ conclusion, lines, premises = [] }) {
+  return {
+    parts: [
+      {
+        showline: { s: conclusion, j: '', isMainConclusion: true, n: '' },
+        parts: lines.map((line, index) => ({
+          n: String(index + 1),
+          s: line.formula,
+          j: line.justification ?? '',
+        })),
+      },
+    ],
+    prems: premises,
+    conc: conclusion,
+  };
+}
+
+function buildNestedProof({ conclusion, parts, premises = [] }) {
+  return {
+    parts: [
+      {
+        showline: { s: conclusion, j: '', isMainConclusion: true, n: '' },
+        parts,
+      },
+    ],
+    prems: premises,
+    conc: conclusion,
+  };
+}
+
+describe('combo-translation-derivation logic systems', () => {
+  it('uses Fitch/Calgary derivation validation when the course logic system is fitch', async () => {
+    const proof = buildNestedProof({
+      premises: ['J → ¬J'],
+      conclusion: '¬J',
+      parts: [
+        { n: '1', s: 'J → ¬J', j: 'Pr' },
+        {
+          parts: [
+            { n: '2', s: 'J', j: 'AS' },
+            { n: '3', s: '¬J', j: '→E 1,2' },
+            { n: '4', s: '⊥', j: '¬E 2,3' },
+          ],
+        },
+        { n: '5', s: '¬J', j: '¬I 2-4' },
+      ],
+    });
+
+    const result = await validateLogicPenguin({
+      question: {
+        type: 'combo-translation-derivation',
+        answer: {
+          premises: ['J → ¬J'],
+          conclusion: '¬J',
+        },
+      },
+      submission: {
+        argumentLine: 'J → ¬J // ¬J',
+        proof,
+      },
+      points: 100,
+      options: { logicSystem: 'fitch' },
+    });
+
+    expect(result.isCorrect).toBe(true);
+    expect(result.score).toBe(100);
+  });
+
+  it('keeps Hurley derivation validation when the course logic system is hurley', async () => {
+    const proof = buildFlatProof({
+      premises: ['A'],
+      conclusion: 'B⊃A',
+      lines: [
+        { formula: 'A', justification: 'Pr' },
+        { formula: 'B', justification: 'ACP' },
+        { formula: 'A', justification: '' },
+        { formula: 'B⊃A', justification: '2-3 CP' },
+      ],
+    });
+
+    const result = await validateLogicPenguin({
+      question: {
+        type: 'combo-translation-derivation',
+        answer: {
+          premises: ['A'],
+          conclusion: 'B⊃A',
+        },
+      },
+      submission: {
+        argumentLine: 'A // B⊃A',
+        proof,
+      },
+      points: 100,
+      options: { logicSystem: 'hurley' },
+    });
+
+    expect(result.isCorrect).toBe(true);
+    expect(result.score).toBe(100);
+  });
+});

--- a/__tests__/derivation-calgary.test.js
+++ b/__tests__/derivation-calgary.test.js
@@ -67,4 +67,31 @@ describe('derivation-calgary checker', () => {
     expect(result.isCorrect).toBe(true);
     expect(result.score).toBe(100);
   });
+
+  it('uses the course logic system for generic derivation validation', async () => {
+    const proof = buildProof({
+      premises: ['P', 'P → Q'],
+      conclusion: 'Q',
+      lines: [
+        { formula: 'P', justification: 'Pr' },
+        { formula: 'P → Q', justification: 'Pr' },
+        { formula: 'Q', justification: '→E 1,2' },
+      ],
+    });
+
+    const result = await validateLogicPenguin({
+      question: {
+        type: 'derivation',
+        prems: ['P', 'P → Q'],
+        conc: 'Q',
+        options: { notation: 'hurley' },
+      },
+      submission: proof,
+      points: 100,
+      options: { logicSystem: 'fitch' },
+    });
+
+    expect(result.isCorrect).toBe(true);
+    expect(result.score).toBe(100);
+  });
 });

--- a/__tests__/derivation-calgary.test.js
+++ b/__tests__/derivation-calgary.test.js
@@ -18,6 +18,19 @@ function buildProof({ conclusion, lines, premises = [] }) {
   };
 }
 
+function buildNestedProof({ conclusion, parts, premises = [] }) {
+  return {
+    parts: [
+      {
+        showline: { s: conclusion, j: '', isMainConclusion: true, n: '' },
+        parts,
+      },
+    ],
+    prems: premises,
+    conc: conclusion,
+  };
+}
+
 describe('derivation-calgary checker', () => {
   it('checks a basic calgary proof', async () => {
     const proof = buildProof({
@@ -32,6 +45,172 @@ describe('derivation-calgary checker', () => {
 
     const result = await checkDerivation(
       { prems: ['P', 'P → Q'], conc: 'Q' },
+      null,
+      proof,
+      false,
+      1,
+      false,
+      {}
+    );
+
+    expect(result.successstatus).toBe('correct');
+    expect(result.points).toBe(1);
+  });
+
+  it('checks a calgary proof with an AS subderivation', async () => {
+    const proof = buildNestedProof({
+      premises: ['J → ¬J'],
+      conclusion: '¬J',
+      parts: [
+        { n: '1', s: 'J → ¬J', j: 'Pr' },
+        {
+          parts: [
+            { n: '2', s: 'J', j: 'AS' },
+            { n: '3', s: '¬J', j: '→E 1,2' },
+            { n: '4', s: '⊥', j: '¬E 2,3' },
+          ],
+        },
+        { n: '5', s: '¬J', j: '¬I 2-4' },
+      ],
+    });
+
+    const result = await checkDerivation(
+      { prems: ['J → ¬J'], conc: '¬J' },
+      null,
+      proof,
+      false,
+      1,
+      false,
+      {}
+    );
+
+    expect(result.successstatus).toBe('correct');
+    expect(result.points).toBe(1);
+  });
+
+  it('accepts Haskell parser aliases for Calgary rules', async () => {
+    const proof = buildProof({
+      premises: ['P', 'P → Q'],
+      conclusion: 'Q',
+      lines: [
+        { formula: 'P', justification: 'Pr' },
+        { formula: 'P → Q', justification: 'Pr' },
+        { formula: 'Q', justification: '->E 1,2' },
+      ],
+    });
+
+    const result = await checkDerivation(
+      { prems: ['P', 'P → Q'], conc: 'Q' },
+      null,
+      proof,
+      false,
+      1,
+      false,
+      {}
+    );
+
+    expect(result.successstatus).toBe('correct');
+    expect(result.points).toBe(1);
+  });
+
+  it('normalizes connective aliases in Calgary formulas and rule names', async () => {
+    const proof = buildProof({
+      premises: ['P', 'Q'],
+      conclusion: 'P ∧ Q',
+      lines: [
+        { formula: 'P', justification: 'Pr' },
+        { formula: 'Q', justification: 'Pr' },
+        { formula: 'P & Q', justification: '/\\I 1,2' },
+      ],
+    });
+
+    const result = await checkDerivation(
+      { prems: ['P', 'Q'], conc: 'P ∧ Q' },
+      null,
+      proof,
+      false,
+      1,
+      false,
+      {}
+    );
+
+    expect(result.successstatus).toBe('correct');
+    expect(result.points).toBe(1);
+  });
+
+  it('rejects bare connective names when the rule requires an intro or elim suffix', async () => {
+    const proof = buildNestedProof({
+      premises: ['J → ¬J'],
+      conclusion: '¬J',
+      parts: [
+        { n: '1', s: 'J → ¬J', j: 'Pr' },
+        {
+          parts: [
+            { n: '2', s: 'J', j: 'AS' },
+            { n: '3', s: '¬J', j: '→ 1,2' },
+            { n: '4', s: '⊥', j: '¬ 2,3' },
+          ],
+        },
+        { n: '5', s: '¬J', j: '¬ 2-4' },
+      ],
+    });
+
+    const result = await checkDerivation(
+      { prems: ['J → ¬J'], conc: '¬J' },
+      null,
+      proof,
+      false,
+      1,
+      false,
+      {}
+    );
+
+    expect(result.successstatus).toBe('incorrect');
+    expect(result.errors['3']?.rule?.high?.['cites a rule (→) that does not exist']).toBe(1);
+  });
+
+  it('rejects flat AS lines outside a subderivation', async () => {
+    const proof = buildProof({
+      premises: [],
+      conclusion: 'J',
+      lines: [
+        { formula: 'J', justification: 'AS' },
+      ],
+    });
+
+    const result = await checkDerivation(
+      { prems: [], conc: 'J' },
+      null,
+      proof,
+      false,
+      1,
+      false,
+      {}
+    );
+
+    expect(result.successstatus).toBe('incorrect');
+    expect(result.errors['1']?.rule?.high?.['AS may only be used inside a subderivation']).toBe(1);
+  });
+
+  it('accepts Hyp as a Calgary assumption compatibility alias', async () => {
+    const proof = buildNestedProof({
+      premises: ['J → ¬J'],
+      conclusion: '¬J',
+      parts: [
+        { n: '1', s: 'J → ¬J', j: 'Pr' },
+        {
+          parts: [
+            { n: '2', s: 'J', j: 'hyp' },
+            { n: '3', s: '¬J', j: '→E 1,2' },
+            { n: '4', s: '⊥', j: '¬E 2,3' },
+          ],
+        },
+        { n: '5', s: '¬J', j: '¬I 2-4' },
+      ],
+    });
+
+    const result = await checkDerivation(
+      { prems: ['J → ¬J'], conc: '¬J' },
       null,
       proof,
       false,

--- a/__tests__/derivation-calgary.test.js
+++ b/__tests__/derivation-calgary.test.js
@@ -1,0 +1,70 @@
+import checkDerivation from '../lib/logicpenguin/checkers/derivation-calgary.js';
+import { validateLogicPenguin } from '../validators/logicpenguin.js';
+
+function buildProof({ conclusion, lines, premises = [] }) {
+  return {
+    parts: [
+      {
+        showline: { s: conclusion, j: '', isMainConclusion: true, n: '' },
+        parts: lines.map((line, index) => ({
+          n: String(index + 1),
+          s: line.formula,
+          j: line.justification ?? '',
+        })),
+      },
+    ],
+    prems: premises,
+    conc: conclusion,
+  };
+}
+
+describe('derivation-calgary checker', () => {
+  it('checks a basic calgary proof', async () => {
+    const proof = buildProof({
+      premises: ['P', 'P → Q'],
+      conclusion: 'Q',
+      lines: [
+        { formula: 'P', justification: 'Pr' },
+        { formula: 'P → Q', justification: 'Pr' },
+        { formula: 'Q', justification: '→E 1,2' },
+      ],
+    });
+
+    const result = await checkDerivation(
+      { prems: ['P', 'P → Q'], conc: 'Q' },
+      null,
+      proof,
+      false,
+      1,
+      false,
+      {}
+    );
+
+    expect(result.successstatus).toBe('correct');
+    expect(result.points).toBe(1);
+  });
+
+  it('is registered for backend validation', async () => {
+    const proof = buildProof({
+      premises: ['P'],
+      conclusion: 'P ∨ Q',
+      lines: [
+        { formula: 'P', justification: 'Pr' },
+        { formula: 'P ∨ Q', justification: '∨I 1' },
+      ],
+    });
+
+    const result = await validateLogicPenguin({
+      question: {
+        type: 'derivation-calgary',
+        prems: ['P'],
+        conc: 'P ∨ Q',
+      },
+      submission: proof,
+      points: 100,
+    });
+
+    expect(result.isCorrect).toBe(true);
+    expect(result.score).toBe(100);
+  });
+});

--- a/__tests__/derivation-calgary.test.js
+++ b/__tests__/derivation-calgary.test.js
@@ -247,6 +247,38 @@ describe('derivation-calgary checker', () => {
     expect(result.score).toBe(100);
   });
 
+  it('preserves explicit derivation-calgary snapshots when the course logic system is hurley', async () => {
+    const proof = buildNestedProof({
+      premises: ['J → ¬J'],
+      conclusion: '¬J',
+      parts: [
+        { n: '1', s: 'J → ¬J', j: 'Pr' },
+        {
+          parts: [
+            { n: '2', s: 'J', j: 'AS' },
+            { n: '3', s: '¬J', j: '→E 1,2' },
+            { n: '4', s: '⊥', j: '¬E 2,3' },
+          ],
+        },
+        { n: '5', s: '¬J', j: '¬I 2-4' },
+      ],
+    });
+
+    const result = await validateLogicPenguin({
+      question: {
+        type: 'derivation-calgary',
+        prems: ['J → ¬J'],
+        conc: '¬J',
+      },
+      submission: proof,
+      points: 100,
+      options: { logicSystem: 'hurley' },
+    });
+
+    expect(result.isCorrect).toBe(true);
+    expect(result.score).toBe(100);
+  });
+
   it('uses the course logic system for generic derivation validation', async () => {
     const proof = buildProof({
       premises: ['P', 'P → Q'],

--- a/__tests__/derivation-hurley.test.js
+++ b/__tests__/derivation-hurley.test.js
@@ -1,5 +1,6 @@
 import checkDerivation from '../lib/logicpenguin/checkers/derivation-hurley.js';
 import getFormulaClass from '../lib/logicpenguin/symbolic/formula.js';
+import { validateLogicPenguin } from '../validators/logicpenguin.js';
 
 function buildProof({ conclusion, lines, premises = [] }) {
   return {
@@ -43,6 +44,33 @@ function collectMessages(errors = {}) {
 }
 
 describe('derivation-hurley ACP/AIP completion', () => {
+  it('preserves explicit derivation-hurley snapshots when the course logic system is fitch', async () => {
+    const proof = buildProof({
+      premises: ['A'],
+      conclusion: 'B⊃A',
+      lines: [
+        { formula: 'A', justification: 'Pr' },
+        { formula: 'B', justification: 'ACP' },
+        { formula: 'A', justification: '' },
+        { formula: 'B⊃A', justification: '2-3 CP' },
+      ],
+    });
+
+    const result = await validateLogicPenguin({
+      question: {
+        type: 'derivation-hurley',
+        prems: ['A'],
+        conc: 'B⊃A',
+      },
+      submission: proof,
+      points: 100,
+      options: { logicSystem: 'fitch' },
+    });
+
+    expect(result.isCorrect).toBe(true);
+    expect(result.score).toBe(100);
+  });
+
   it('round trips normalized quantified conditionals inside negations', () => {
     const Formula = getFormulaClass();
     const formula = Formula.from('~~(∃xAx ⊃ ~Cbc)');

--- a/__tests__/derivation-hurley.test.js
+++ b/__tests__/derivation-hurley.test.js
@@ -62,7 +62,6 @@ describe('derivation-hurley ACP/AIP completion', () => {
     expect(result.successstatus).toBe('incorrect');
     expect(collectMessages(result.errors)).toEqual(
       expect.arrayContaining([
-        'Conditional Proof sequence not discharged.',
         'open ACP/AIP subderivations must be closed with CP/IP before the proof is complete',
         'final conclusion of argument not shown',
       ])
@@ -81,7 +80,6 @@ describe('derivation-hurley ACP/AIP completion', () => {
     expect(result.successstatus).toBe('incorrect');
     expect(collectMessages(result.errors)).toEqual(
       expect.arrayContaining([
-        'Indirect Proof sequence not discharged.',
         'open ACP/AIP subderivations must be closed with CP/IP before the proof is complete',
         'final conclusion of argument not shown',
       ])
@@ -102,7 +100,6 @@ describe('derivation-hurley ACP/AIP completion', () => {
     expect(result.successstatus).toBe('incorrect');
     expect(collectMessages(result.errors)).toEqual(
       expect.arrayContaining([
-        'Conditional Proof sequence not discharged.',
         'open ACP/AIP subderivations must be closed with CP/IP before the proof is complete',
       ])
     );
@@ -126,7 +123,6 @@ describe('derivation-hurley ACP/AIP completion', () => {
     expect(result.successstatus).toBe('incorrect');
     expect(collectMessages(result.errors)).toEqual(
       expect.arrayContaining([
-        'Conditional Proof sequence not discharged.',
         'open ACP/AIP subderivations must be closed with CP/IP before the proof is complete',
         'final conclusion of argument not shown',
       ])

--- a/lib/logicSystems.js
+++ b/lib/logicSystems.js
@@ -1,0 +1,56 @@
+export const DEFAULT_LOGIC_SYSTEM = 'fitch';
+export const LEGACY_LOGIC_SYSTEM = 'hurley';
+
+export const LOGIC_SYSTEMS = {
+  fitch: {
+    id: 'fitch',
+    label: 'Fitch',
+    derivationSystem: 'calgary',
+    symbols: {
+      not: '¬',
+      and: '∧',
+      or: '∨',
+      conditional: '→',
+      biconditional: '↔',
+      forall: '∀',
+      exists: '∃',
+    },
+  },
+  hurley: {
+    id: 'hurley',
+    label: 'Hurley',
+    derivationSystem: 'hurley',
+    symbols: {
+      not: '~',
+      and: '•',
+      or: '∨',
+      conditional: '⊃',
+      biconditional: '≡',
+      forall: '∀',
+      exists: '∃',
+    },
+  },
+};
+
+export function isLogicSystem(value) {
+  return typeof value === 'string' && value in LOGIC_SYSTEMS;
+}
+
+export function normalizeLogicSystem(value, fallback = DEFAULT_LOGIC_SYSTEM) {
+  return isLogicSystem(value) ? value : fallback;
+}
+
+export function getLogicSystem(value, fallback = DEFAULT_LOGIC_SYSTEM) {
+  return LOGIC_SYSTEMS[normalizeLogicSystem(value, fallback)];
+}
+
+export function getDerivationProblemType(value, fallback = DEFAULT_LOGIC_SYSTEM) {
+  return `derivation-${getLogicSystem(value, fallback).derivationSystem}`;
+}
+
+export function getLogicSystemOptions() {
+  return Object.keys(LOGIC_SYSTEMS).map((id) => ({
+    id,
+    label: LOGIC_SYSTEMS[id].label,
+  }));
+}

--- a/lib/logicpenguin/checkers/combo-translation-derivation.js
+++ b/lib/logicpenguin/checkers/combo-translation-derivation.js
@@ -7,7 +7,7 @@
 ////////////////////////////////////////////////////////////////////////
 
 import tr from '../translate.js';
-import derivationHurley from './derivation-hurley.js';
+import { getDerivationCheckerForLogicSystem } from './derivation-by-logic-system.js';
 import getFormulaClass from '../symbolic/formula.js';
 import { equivtest } from '../symbolic/libequivalence.js';
 
@@ -148,7 +148,8 @@ export default async function(
             prems: given.premises,
             conc: given.conclusion,
         };
-        const derivResult = await derivationHurley(
+        const derivationChecker = getDerivationCheckerForLogicSystem(options?.logicSystem);
+        const derivResult = await derivationChecker(
             derivQuestion,
             null,
             providedProof,

--- a/lib/logicpenguin/checkers/combo-translation-truth-table.js
+++ b/lib/logicpenguin/checkers/combo-translation-truth-table.js
@@ -136,7 +136,7 @@ export default async function(
         const conclusion = given.conclusion;
         const pwffs = premises.map((p)=> Formula.from(p));
         const cwff = Formula.from(conclusion);
-        const tablesShouldBe = argumentTables(pwffs, cwff);
+        const tablesShouldBe = argumentTables(pwffs, cwff, notation);
         const tcQ = {
             prems: premises,
             conc: conclusion

--- a/lib/logicpenguin/checkers/derivation-by-logic-system.js
+++ b/lib/logicpenguin/checkers/derivation-by-logic-system.js
@@ -1,0 +1,13 @@
+import { getDerivationProblemType } from '../../logicSystems.js';
+import derivationCalgary from './derivation-calgary.js';
+import derivationHurley from './derivation-hurley.js';
+
+const DERIVATION_CHECKERS_BY_TYPE = {
+    'derivation-calgary': derivationCalgary,
+    'derivation-hurley': derivationHurley,
+};
+
+export function getDerivationCheckerForLogicSystem(logicSystem, fallback = 'hurley') {
+    const checkerKey = getDerivationProblemType(logicSystem, fallback);
+    return DERIVATION_CHECKERS_BY_TYPE[checkerKey] ?? derivationHurley;
+}

--- a/lib/logicpenguin/checkers/derivation-calgary.js
+++ b/lib/logicpenguin/checkers/derivation-calgary.js
@@ -10,6 +10,11 @@ import getRules from './rules/forallx-rules.js';
 import DerivationCheck from './derivation-check.js';
 import { justParse } from '../justification-parse.js';
 import getFormulaClass from '../symbolic/formula.js';
+import {
+    addRequiredRuleErrors,
+    applyRuleFilters,
+    getRulesetRestrictions,
+} from './derivation-rule-restrictions.js';
 
 // default notation from settings, but calgary otherwise
 let defaultnotation = 'calgary';
@@ -75,7 +80,14 @@ export default async function(
     // clone the answer to avoid messing it up when checking it
     const ansclone = JSON.parse(JSON.stringify(givenans));
     const notationname = (options?.notation ?? defaultnotation);
-    const rules = getRules('calgary', notationname);
+    const { allow, deny, require, requireAny } = getRulesetRestrictions(question, options);
+    const normalizeForNotation = (rule) => normalizeRuleName(rule, notationname);
+    const rules = applyRuleFilters(
+        getRules('calgary', notationname),
+        allow,
+        deny,
+        normalizeForNotation
+    );
     const checkResult = new DerivationCheck(
         rules,
         ansclone,
@@ -83,6 +95,7 @@ export default async function(
         question.conc,
         { notation: notationname, assumptionMode: 'nested' }
     ).report();
+    addRequiredRuleErrors(checkResult, ansclone, require, requireAny, normalizeForNotation);
     // only correct if no errors
     const correct = (Object.keys(checkResult.errors).length == 0);
     let portion = 1;

--- a/lib/logicpenguin/checkers/derivation-calgary.js
+++ b/lib/logicpenguin/checkers/derivation-calgary.js
@@ -1,0 +1,108 @@
+// LICENSE: GNU GPL v3 You should have received a copy of the GNU General
+// Public License along with this program. If not, see
+// https://www.gnu.org/licenses/.
+
+///////////////// checkers/derivation-calgary.js /////////////////////
+// calgary-specific derivation checker, uses derivation-check.js    //
+//////////////////////////////////////////////////////////////////////
+
+import getRules from './rules/forallx-rules.js';
+import DerivationCheck from './derivation-check.js';
+import { justParse } from '../justification-parse.js';
+
+// default notation from settings, but calgary otherwise
+let defaultnotation = 'calgary';
+if ((typeof process != "undefined") && (process?.appsettings?.defaultnotation)) {
+    defaultnotation = process.appsettings.defaultnotation;
+}
+
+// try to determine which lines are actual progress
+function progresslinesin(deriv, errors, rules) {
+    let ttl = 0;
+    // skip empty subderivations
+    if (!("parts" in deriv)) { return 0; }
+    for (let pt of deriv.parts) {
+        // recursively apply to subdirevations
+        if ("parts" in pt) {
+            ttl+= progresslinesin(pt, errors, rules);
+        }
+        // skip lines without line numbers or justifications
+        if ((!("n" in pt)) || (!("j" in pt))) {
+            continue;
+        }
+        // lines with errors are not progress
+        if (pt.n in errors) {
+            let badfound = false;
+            for (let cat in errors[pt.n]) {
+                if (cat != 'dependency') {
+                    badfound = true;
+                    break;
+                }
+            }
+            if (badfound) { continue; }
+        }
+        // determine kind of out rule
+        const { nums, ranges, citedrules } = justParse(pt.j);
+        if (citedrules.length < 1) { continue; }
+        const rule = citedrules[0];
+        // skip nonexistent rules
+        if (!(rule in rules)) {
+            continue;
+        }
+        // do not premises, assumptions, in-rules to avoid cheese
+        if (!(rules[rule].premiserule) &&
+            !(rules[rule].assumptionrule) &&
+            !(/I$/.test(rule))) {
+            ttl++;
+        }
+    }
+    return ttl;
+}
+
+export default async function(
+    question, answer, givenans, partialcredit, points, cheat, options
+) {
+    // clone the answer to avoid messing it up when checking it
+    const ansclone = JSON.parse(JSON.stringify(givenans));
+    const notationname = (options?.notation ?? defaultnotation);
+    const rules = getRules('calgary', notationname);
+    const checkResult = new DerivationCheck(
+        rules,
+        ansclone,
+        question.prems,
+        question.conc,
+        { notation: notationname }
+    ).report();
+    // only correct if no errors
+    const correct = (Object.keys(checkResult.errors).length == 0);
+    let portion = 1;
+    // try to determine partial credit by checking progress vs needed
+    // progress
+    if (partialcredit && !correct) {
+        // get maximum credit from derivation check
+        const initialportion = checkResult.pointsportion ?? 0;
+        portion = initialportion;
+        // check number of good lines versus answer's good lines
+        const goalprogress = progresslinesin(answer, {}, rules);
+        const actualprogress = progresslinesin(givenans, checkResult.errors, rules);
+        const progportion = (actualprogress / goalprogress);
+        // if mostly wrong, we give points on the number of good steps
+        if (initialportion < 0.5) {
+            let buildup = actualprogress * 0.1;
+            if (buildup > 0.5) { buildup = 0.5; }
+            portion = Math.max(initialportion, buildup);
+        }
+        // maximum of 0.8 for incomplete derivations
+        if (progportion < 0.8) {
+            portion = (portion * progportion);
+        }
+        points = Math.floor(portion * points);
+    } else {
+        points = (correct) ? points : 0;
+    }
+    return {
+        successstatus: (correct ? "correct" : "incorrect"),
+        errors: checkResult.errors,
+        points: points
+    }
+}

--- a/lib/logicpenguin/checkers/derivation-calgary.js
+++ b/lib/logicpenguin/checkers/derivation-calgary.js
@@ -9,6 +9,7 @@
 import getRules from './rules/forallx-rules.js';
 import DerivationCheck from './derivation-check.js';
 import { justParse } from '../justification-parse.js';
+import getFormulaClass from '../symbolic/formula.js';
 
 // default notation from settings, but calgary otherwise
 let defaultnotation = 'calgary';
@@ -16,15 +17,24 @@ if ((typeof process != "undefined") && (process?.appsettings?.defaultnotation)) 
     defaultnotation = process.appsettings.defaultnotation;
 }
 
+function normalizeRuleName(rule, notationname = defaultnotation) {
+    if (!rule) return '';
+    const syntax = getFormulaClass(notationname).syntax;
+    const normalized = DerivationCheck.normalizeRuleSymbolName(rule, syntax);
+    return DerivationCheck.ruleAliases?.[normalized] ||
+        DerivationCheck.ruleAliases?.[rule] ||
+        normalized;
+}
+
 // try to determine which lines are actual progress
-function progresslinesin(deriv, errors, rules) {
+function progresslinesin(deriv, errors, rules, notationname = defaultnotation) {
     let ttl = 0;
     // skip empty subderivations
     if (!("parts" in deriv)) { return 0; }
     for (let pt of deriv.parts) {
         // recursively apply to subdirevations
         if ("parts" in pt) {
-            ttl+= progresslinesin(pt, errors, rules);
+            ttl+= progresslinesin(pt, errors, rules, notationname);
         }
         // skip lines without line numbers or justifications
         if ((!("n" in pt)) || (!("j" in pt))) {
@@ -44,7 +54,7 @@ function progresslinesin(deriv, errors, rules) {
         // determine kind of out rule
         const { nums, ranges, citedrules } = justParse(pt.j);
         if (citedrules.length < 1) { continue; }
-        const rule = citedrules[0];
+        const rule = normalizeRuleName(citedrules[0], notationname);
         // skip nonexistent rules
         if (!(rule in rules)) {
             continue;
@@ -71,7 +81,7 @@ export default async function(
         ansclone,
         question.prems,
         question.conc,
-        { notation: notationname }
+        { notation: notationname, assumptionMode: 'nested' }
     ).report();
     // only correct if no errors
     const correct = (Object.keys(checkResult.errors).length == 0);
@@ -83,8 +93,8 @@ export default async function(
         const initialportion = checkResult.pointsportion ?? 0;
         portion = initialportion;
         // check number of good lines versus answer's good lines
-        const goalprogress = progresslinesin(answer, {}, rules);
-        const actualprogress = progresslinesin(givenans, checkResult.errors, rules);
+        const goalprogress = progresslinesin(answer, {}, rules, notationname);
+        const actualprogress = progresslinesin(givenans, checkResult.errors, rules, notationname);
         const progportion = (actualprogress / goalprogress);
         // if mostly wrong, we give points on the number of good steps
         if (initialportion < 0.5) {

--- a/lib/logicpenguin/checkers/derivation-check.js
+++ b/lib/logicpenguin/checkers/derivation-check.js
@@ -48,7 +48,7 @@ export default class DerivationCheck {
     };
 
     constructor(rules, deriv, prems, conc, options = {}) {
-        const Formula = getFormulaClass();
+        const Formula = getFormulaClass(options.notation);
         this.Formula = Formula;
         this.syntax = Formula.syntax;
         this.rules = rules;

--- a/lib/logicpenguin/checkers/derivation-check.js
+++ b/lib/logicpenguin/checkers/derivation-check.js
@@ -10,6 +10,8 @@ import getFormulaClass from '../symbolic/formula.js';
 import { justParse } from '../justification-parse.js';
 import { arrayUnion, perms } from '../misc.js';
 
+const FLAT_OPENING_RULES = new Set(['ACP', 'AIP']);
+const FLAT_CLOSING_RULES = new Set(['CP', 'IP']);
 
 export default class DerivationCheck {
     static ruleAliases = {
@@ -41,11 +43,32 @@ export default class DerivationCheck {
         'qn': 'QN', 'Qn': 'QN', 'qN': 'QN',
         
         'UD': 'UG', // logicpenguin compatibility
+        'as': 'AS', 'As': 'AS',
+        'hyp': 'Hyp', 'HYP': 'Hyp',
+        'dne': 'DNE', 'Dne': 'DNE',
+        'lem': 'LEM', 'Lem': 'LEM',
+        'dem': 'DeM', 'Dem': 'DeM',
         'cp': 'CP', 'Cp': 'CP', 'cP': 'CP',
         'ip': 'IP', 'Ip': 'IP', 'iP': 'IP',
         'acp': 'ACP', 'Acp': 'ACP', 'AcP': 'ACP', 'aCp': 'ACP', 'acP': 'ACP',
         'aip': 'AIP', 'Aip': 'AIP', 'AiP': 'AIP', 'aIp': 'AIP', 'aiP': 'AIP',
     };
+
+    static normalizeRuleSymbolName(rule, syntax) {
+        const raw = String(rule ?? '').trim();
+        const match = raw.match(/^(.+)([iIeE])$/);
+        if (!match) { return raw; }
+        let connective = match[1];
+        if (/^v$/i.test(connective)) {
+            connective = syntax?.symbols?.OR ?? '∨';
+        } else if (connective === '-' || connective === '–') {
+            connective = syntax?.symbols?.NOT ?? '¬';
+        } else if (syntax?.symbolfix) {
+            connective = syntax.symbolfix(connective);
+        }
+        if (/^[A-Za-z]+$/.test(connective)) { return raw; }
+        return connective + match[2].toUpperCase();
+    }
 
     constructor(rules, deriv, prems, conc, options = {}) {
         const Formula = getFormulaClass(options.notation);
@@ -57,6 +80,7 @@ export default class DerivationCheck {
         this.conc = Formula.from(conc).normal;
         this.errors = {};
         this.allowOpenScopeCitations = Boolean(options.allowOpenScopeCitations);
+        this.flatAssumptions = options.assumptionMode !== 'nested';
     }
 
     adderror(target, category, severity, desc) {
@@ -81,11 +105,16 @@ export default class DerivationCheck {
     }
 
     normalizeRuleName(rule) {
-        if (!rule) { return ''; }
-        if (rule in DerivationCheck.ruleAliases) {
-            return DerivationCheck.ruleAliases[rule];
+        const raw = String(rule ?? '').trim();
+        if (!raw) { return ''; }
+        const normalized = DerivationCheck.normalizeRuleSymbolName(raw, this.syntax);
+        if (normalized in DerivationCheck.ruleAliases) {
+            return DerivationCheck.ruleAliases[normalized];
         }
-        return rule;
+        if (raw in DerivationCheck.ruleAliases) {
+            return DerivationCheck.ruleAliases[raw];
+        }
+        return normalized;
     }
 
     resolveRuleName(line) {
@@ -177,39 +206,15 @@ export default class DerivationCheck {
             const openAssumptions = Array.isArray(line?.openAssumptions)
                 ? line.openAssumptions
                 : [];
-            // only a conclusion in the main proof scope can finish the proof
             if (lineNorm === this.conc && openAssumptions.length === 0) {
                 hasMainScopeConclusion = true;
             }
         }
-        const unresolvedAssumptions = Array.isArray(lastSubstantiveLine?.openAssumptions)
-            ? lastSubstantiveLine.openAssumptions
-            : [];
-        // the last real line tells us whether an acp or aip is still open
-        if (unresolvedAssumptions.length > 0) {
-            const unresolvedRules = new Set(
-                unresolvedAssumptions.map((assumptionLine) =>
-                    this.resolveRuleName(assumptionLine)
-                )
-            );
-            if (unresolvedRules.has('ACP')) {
-                this.adderror(
-                    lastSubstantiveLine?.n || '1',
-                    "dependency",
-                    "low",
-                    "Conditional Proof sequence not discharged."
-                );
-            }
-            if (unresolvedRules.has('AIP')) {
-                this.adderror(
-                    lastSubstantiveLine?.n || '1',
-                    "dependency",
-                    "low",
-                    "Indirect Proof sequence not discharged."
-                );
-            }
+        const stillOpen = Array.isArray(lastSubstantiveLine?.openAssumptions) &&
+            lastSubstantiveLine.openAssumptions.length > 0;
+        if (this.flatAssumptions && stillOpen) {
             this.adderror(
-                lastSubstantiveLine?.n || '1',
+                lastSubstantiveLine.n || '1',
                 "completion",
                 "high",
                 "open ACP/AIP subderivations must be closed with CP/IP before the proof is complete"
@@ -374,10 +379,11 @@ export default class DerivationCheck {
                 rulename + '” found');
             return line;
         }
-        if (rulename === 'ACP') { return this.checkACP(line); }
-        if (rulename === 'AIP') { return this.checkAIP(line); }
-        if (rulename === 'CP') { return this.checkCP(line); }
-        if (rulename === 'IP') { return this.checkIP(line); }
+        if (this.flatAssumptions && FLAT_OPENING_RULES.has(rulename)) { return this.checkFlatAssumption(line, rulename); }
+        if (this.flatAssumptions && FLAT_CLOSING_RULES.has(rulename)) {
+            if (rulename === 'CP') { return this.checkCP(line); }
+            if (rulename === 'IP') { return this.checkIP(line); }
+        }
         // PREMISE
         if (rule?.premiserule) {
             const norm = Formula.from(line.s).normal;
@@ -398,6 +404,13 @@ export default class DerivationCheck {
         }
         // fitch assumptions start subderivations
         if (rule?.assumptionrule) {
+            const isMainScope = line.mysubderiv === this.deriv ||
+                line.mysubderiv?.showline?.isMainConclusion;
+            if (!this.flatAssumptions && isMainScope) {
+                this.adderror(line.n, 'rule', 'high',
+                    rulename + ' may only be used inside a subderivation');
+                return line;
+            }
             line.mysubderiv.assumptions.push(Formula.from(line.s).normal);
             line.checkedOK = true;
             return line;
@@ -537,7 +550,26 @@ export default class DerivationCheck {
         return line;
     }
 
-    computeIndents() {
+    computeNestedScopes() {
+        if (!this?.deriv?.lines) { return; }
+        for (const line of this.deriv.lines) {
+            const assumptions = [];
+            let subderiv = line?.mysubderiv;
+            while (subderiv && subderiv !== this.deriv) {
+                const assumptionLine = subderiv.lines?.[0];
+                const ruleName = this.resolveRuleName(assumptionLine);
+                if (assumptionLine && this.rules?.[ruleName]?.assumptionrule) {
+                    assumptions.unshift(assumptionLine);
+                }
+                subderiv = subderiv.parentderiv;
+            }
+            line.closedAssumption = null;
+            line.openAssumptions = assumptions;
+            line.indent = line.openAssumptions.length;
+        }
+    }
+
+    computeFlatScopes() {
         if (!this?.deriv?.lines) { return; }
         let indentLevel = 0;
         const assumptionStack = [];
@@ -548,7 +580,7 @@ export default class DerivationCheck {
             line.closedAssumption = null;
             const ruleName = this.resolveRuleName(line);
 
-            if (ruleName === 'ACP' || ruleName === 'AIP') {
+            if (FLAT_OPENING_RULES.has(ruleName)) {
                 if (indentLevel >= 3) {
                     this.adderror(line.n, "rule", "high",
                         "Maximum nested assumption depth (3) exceeded.");
@@ -560,7 +592,7 @@ export default class DerivationCheck {
                 continue;
             }
 
-            if (ruleName === 'CP' || ruleName === 'IP') {
+            if (FLAT_CLOSING_RULES.has(ruleName)) {
                 if (indentLevel === 0 || assumptionStack.length === 0) {
                     this.adderror(line.n, "rule", "high",
                         "CP/IP used with no open assumption.");
@@ -577,6 +609,14 @@ export default class DerivationCheck {
             line.indent = indentLevel;
             line.openAssumptions = [...assumptionStack];
         }
+    }
+
+    computeIndents() {
+        if (this.flatAssumptions) {
+            this.computeFlatScopes();
+            return;
+        }
+        this.computeNestedScopes();
     }
 
     findMostRecentOpenAssumption(currentLine, ruleName, formula) {
@@ -668,20 +708,10 @@ export default class DerivationCheck {
         return null;
     }
 
-    checkACP(line) {
+    checkFlatAssumption(line, rulename) {
         if (!line?.formulaNormal) {
             this.adderror(line.n, "rule", "high",
-                "ACP requires an assumption.");
-            return line;
-        }
-        line.checkedOK = true;
-        return line;
-    }
-
-    checkAIP(line) {
-        if (!line?.formulaNormal) {
-            this.adderror(line.n, "rule", "high",
-                "AIP requires an assumption.");
+                rulename + " requires an assumption.");
             return line;
         }
         line.checkedOK = true;
@@ -963,7 +993,7 @@ export default class DerivationCheck {
             return false;
         }
         const rulename = this.resolveRuleName(line);
-        if (rulename === 'CP' || rulename === 'IP') {
+        if (this.flatAssumptions && FLAT_CLOSING_RULES.has(rulename)) {
             // For Hurley-style flat indentation, allow simple ranges with no subderiv structure
             if (start < parseInt(line.n) && end < parseInt(line.n)) {
                 return true;

--- a/lib/logicpenguin/checkers/derivation-check.js
+++ b/lib/logicpenguin/checkers/derivation-check.js
@@ -396,6 +396,12 @@ export default class DerivationCheck {
             }
             return line;
         }
+        // fitch assumptions start subderivations
+        if (rule?.assumptionrule) {
+            line.mysubderiv.assumptions.push(Formula.from(line.s).normal);
+            line.checkedOK = true;
+            return line;
+        }
         // EQUIVALENCE RULE
         if (rule?.replacementrule) {
             const equivcheck = (new replacementRuleCheck(rule, rulename,

--- a/lib/logicpenguin/checkers/derivation-hurley.js
+++ b/lib/logicpenguin/checkers/derivation-hurley.js
@@ -102,7 +102,7 @@ export default async function(
         ansclone,
         question.prems,
         question.conc,
-        { allowOpenScopeCitations: true }
+        { allowOpenScopeCitations: true, assumptionMode: 'flat' }
     ).report();
     const required = new Set(
         (Array.isArray(require) ? require : [])

--- a/lib/logicpenguin/checkers/derivation-hurley.js
+++ b/lib/logicpenguin/checkers/derivation-hurley.js
@@ -8,74 +8,16 @@
 
 import getRules from './rules/hurley-rules.js';
 import DerivationCheck from './derivation-check.js';
-import { justParse } from '../justification-parse.js';
+import {
+    addRequiredRuleErrors,
+    applyRuleFilters,
+    getRulesetRestrictions,
+} from './derivation-rule-restrictions.js';
 
 function normalizeRuleName(rule) {
     if (!rule) return '';
     const alias = DerivationCheck.ruleAliases?.[rule];
     return alias || rule;
-}
-
-function applyRuleFilters(rules, allow, deny) {
-    const allowSet = new Set(
-        (Array.isArray(allow) ? allow : [])
-            .map((rule) => normalizeRuleName(String(rule).trim()))
-            .filter(Boolean)
-    );
-    const denySet = new Set(
-        (Array.isArray(deny) ? deny : [])
-            .map((rule) => normalizeRuleName(String(rule).trim()))
-            .filter(Boolean)
-    );
-
-    if (allowSet.size === 0 && denySet.size === 0) {
-        return rules;
-    }
-
-    const filtered = {};
-    for (const [name, rule] of Object.entries(rules)) {
-        if (name === 'Pr' || name === 'Ass') {
-            // keep premise + assumption rules no matter what
-            filtered[name] = rule;
-            continue;
-        }
-
-        const normalized = normalizeRuleName(name);
-        if (denySet.has(normalized)) {
-            continue;
-        }
-        if (allowSet.size > 0 && !allowSet.has(normalized)) {
-            continue;
-        }
-        filtered[name] = rule;
-    }
-
-    return filtered;
-}
-
-function collectCitedRules(proof) {
-    const cited = new Set();
-    const walk = (subderiv) => {
-        if (!subderiv) return;
-        const parts = Array.isArray(subderiv.parts) ? subderiv.parts : [];
-        for (const part of parts) {
-            if (part?.parts) {
-                walk(part);
-                continue;
-            }
-            const justification = part?.j ?? '';
-            if (!justification) continue;
-            const { citedrules } = justParse(justification);
-            for (const rule of citedrules) {
-                const normalized = normalizeRuleName(String(rule).trim());
-                if (normalized) {
-                    cited.add(normalized);
-                }
-            }
-        }
-    };
-    walk(proof);
-    return cited;
 }
 
 export default async function(
@@ -92,11 +34,8 @@ export default async function(
     }
     // clone the answer to avoid messing it up when checking it
     const ansclone = JSON.parse(JSON.stringify(proof));
-    const allow = options?.ruleset?.allow || question?.ruleset?.allow;
-    const deny = options?.ruleset?.deny || question?.ruleset?.deny;
-    const require = options?.ruleset?.require || question?.ruleset?.require;
-    const requireAny = options?.ruleset?.requireAny || question?.ruleset?.requireAny;
-    const rules = applyRuleFilters(getRules(), allow, deny);
+    const { allow, deny, require, requireAny } = getRulesetRestrictions(question, options);
+    const rules = applyRuleFilters(getRules(), allow, deny, normalizeRuleName);
     const checkResult = new DerivationCheck(
         rules,
         ansclone,
@@ -104,42 +43,7 @@ export default async function(
         question.conc,
         { allowOpenScopeCitations: true, assumptionMode: 'flat' }
     ).report();
-    const required = new Set(
-        (Array.isArray(require) ? require : [])
-            .map((rule) => normalizeRuleName(String(rule).trim()))
-            .filter(Boolean)
-    );
-    if (required.size > 0) {
-        const used = collectCitedRules(ansclone);
-        const missing = Array.from(required).filter((rule) => !used.has(rule));
-        if (missing.length > 0) {
-            checkResult.errors = checkResult.errors || {};
-            checkResult.errors['??'] = checkResult.errors['??'] || {};
-            checkResult.errors['??'].rule = checkResult.errors['??'].rule || {};
-            checkResult.errors['??'].rule.high = checkResult.errors['??'].rule.high || {};
-            checkResult.errors['??'].rule.high[
-                `missing required rules: ${missing.join(', ')}`
-            ] = 1;
-        }
-    }
-    const requireAnySet = new Set(
-        (Array.isArray(requireAny) ? requireAny : [])
-            .map((rule) => normalizeRuleName(String(rule).trim()))
-            .filter(Boolean)
-    );
-    if (requireAnySet.size > 0) {
-        const used = collectCitedRules(ansclone);
-        const satisfied = Array.from(requireAnySet).some((rule) => used.has(rule));
-        if (!satisfied) {
-            checkResult.errors = checkResult.errors || {};
-            checkResult.errors['??'] = checkResult.errors['??'] || {};
-            checkResult.errors['??'].rule = checkResult.errors['??'].rule || {};
-            checkResult.errors['??'].rule.high = checkResult.errors['??'].rule.high || {};
-            checkResult.errors['??'].rule.high[
-                `use at least one of: ${Array.from(requireAnySet).join(', ')}`
-            ] = 1;
-        }
-    }
+    addRequiredRuleErrors(checkResult, ansclone, require, requireAny, normalizeRuleName);
     // only correct if no errors
     const correct = (Object.keys(checkResult.errors).length == 0);
     points = (correct) ? points : 0;

--- a/lib/logicpenguin/checkers/derivation-rule-restrictions.js
+++ b/lib/logicpenguin/checkers/derivation-rule-restrictions.js
@@ -1,0 +1,112 @@
+import { justParse } from '../justification-parse.js';
+
+function firstDefined(...values) {
+    return values.find((value) => value !== undefined);
+}
+
+function normalizeRuleList(value, normalizeRuleName) {
+    const source = Array.isArray(value)
+        ? value
+        : String(value || '').split(/[,\s]+/g);
+    const out = [];
+    const seen = new Set();
+    for (const entry of source) {
+        const normalized = normalizeRuleName(String(entry).trim());
+        if (!normalized) continue;
+        const key = normalized.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        out.push(normalized);
+    }
+    return out;
+}
+
+export function getRulesetRestrictions(question, options) {
+    const optionRules = options?.ruleset || {};
+    const questionRules = question?.ruleset || {};
+    return {
+        allow: firstDefined(optionRules.allow, optionRules.allowed, questionRules.allow, questionRules.allowed),
+        deny: firstDefined(
+            optionRules.deny,
+            optionRules.disallow,
+            optionRules.disallowed,
+            optionRules.forbid,
+            optionRules.forbidden,
+            questionRules.deny,
+            questionRules.disallow,
+            questionRules.disallowed,
+            questionRules.forbid,
+            questionRules.forbidden
+        ),
+        require: firstDefined(optionRules.require, optionRules.required, questionRules.require, questionRules.required),
+        requireAny: firstDefined(
+            optionRules.requireAny,
+            optionRules.requiredAny,
+            questionRules.requireAny,
+            questionRules.requiredAny
+        ),
+    };
+}
+
+export function applyRuleFilters(rules, allow, deny, normalizeRuleName) {
+    const allowSet = new Set(normalizeRuleList(allow, normalizeRuleName).map((rule) => rule.toLowerCase()));
+    const denySet = new Set(normalizeRuleList(deny, normalizeRuleName).map((rule) => rule.toLowerCase()));
+    if (allowSet.size === 0 && denySet.size === 0) {
+        return rules;
+    }
+
+    const filtered = {};
+    for (const [name, rule] of Object.entries(rules)) {
+        if (rule?.premiserule) {
+            filtered[name] = rule;
+            continue;
+        }
+        const key = normalizeRuleName(name).toLowerCase();
+        if (denySet.has(key)) continue;
+        if (allowSet.size > 0 && !allowSet.has(key)) continue;
+        filtered[name] = rule;
+    }
+    return filtered;
+}
+
+function collectCitedRuleKeys(proof, normalizeRuleName) {
+    const cited = new Set();
+    const walk = (subderiv) => {
+        if (!subderiv) return;
+        for (const part of Array.isArray(subderiv.parts) ? subderiv.parts : []) {
+            if (part?.parts) {
+                walk(part);
+                continue;
+            }
+            const { citedrules } = justParse(part?.j ?? '');
+            for (const rule of citedrules) {
+                const normalized = normalizeRuleName(String(rule).trim());
+                if (normalized) cited.add(normalized.toLowerCase());
+            }
+        }
+    };
+    walk(proof);
+    return cited;
+}
+
+function addRuleError(checkResult, message) {
+    checkResult.errors = checkResult.errors || {};
+    checkResult.errors['??'] = checkResult.errors['??'] || {};
+    checkResult.errors['??'].rule = checkResult.errors['??'].rule || {};
+    checkResult.errors['??'].rule.high = checkResult.errors['??'].rule.high || {};
+    checkResult.errors['??'].rule.high[message] = 1;
+}
+
+export function addRequiredRuleErrors(checkResult, proof, require, requireAny, normalizeRuleName) {
+    const used = collectCitedRuleKeys(proof, normalizeRuleName);
+    const required = normalizeRuleList(require, normalizeRuleName);
+    const missing = required.filter((rule) => !used.has(rule.toLowerCase()));
+    if (missing.length > 0) {
+        addRuleError(checkResult, `missing required rules: ${missing.join(', ')}`);
+    }
+
+    const requireAnyList = normalizeRuleList(requireAny, normalizeRuleName);
+    if (requireAnyList.length > 0 && !requireAnyList.some((rule) => used.has(rule.toLowerCase()))) {
+        addRuleError(checkResult, `use at least one of: ${requireAnyList.join(', ')}`);
+    }
+}

--- a/lib/logicpenguin/checkers/partial-truth-table.js
+++ b/lib/logicpenguin/checkers/partial-truth-table.js
@@ -34,7 +34,7 @@ function computeExpected(question, options) {
     }
     const Formula = getFormulaClass(options?.notation);
     const wff = Formula.from(statement);
-    const tables = multiTables([wff]);
+    const tables = multiTables([wff], options?.notation);
     const tokens = tables?.tables?.[0]?.tokens ?? [];
     const rows = tables?.tables?.[0]?.rows ?? [];
 

--- a/lib/logicpenguin/checkers/rules/forallx-rules.js
+++ b/lib/logicpenguin/checkers/rules/forallx-rules.js
@@ -1,0 +1,268 @@
+// LICENSE: GNU GPL v3 You should have received a copy of the GNU General
+// Public License along with this program. If not, see
+// https://www.gnu.org/licenses/.
+
+///////////////////// forallx-rules.js //////////////////////////////////////
+// defines the inference rules for various forallx-style derivation systems//
+/////////////////////////////////////////////////////////////////////////////
+
+// Note: all rulesets should be done with Cambridge notation; will be
+// swapped out for the correct thingamig
+
+// UConn = Calgary rules with Cambridge notation
+
+import notations from '../../symbolic/notations.js';
+
+const opnames = ['NOT','OR','AND','IFF','IFTHEN','FORALL','EXISTS','FALSUM'];
+
+const rulesrepository = {};
+
+const allRules = {};
+
+allRules.common = {
+    "∨I"  : { forms: [ { prems: ["A"], conc: "A ∨ B" }, { prems: ["A"], conc: "B ∨ A" } ] },
+    "∧I"  : { forms: [ { prems: ["A", "B"], conc: "A ∧ B" } ] },
+    "→I"  : { forms: [ { conc: "A → B", subderivs: [ { needs: ["B"], allows: "A" } ] } ] },
+    "↔I"  : { forms: [ { conc: "A ↔ B", subderivs: [ { needs: ["B"], allows: "A" }, { needs: ["A"], allows: "B" } ] } ] },
+    "¬I"  : { forms: [ { conc: "¬A", subderivs: [ { needs: ["⊥"], allows: "A" } ] } ] },
+    "∀I"  : { pred: true, forms: [ { prems: ["Aa"], conc: "∀xAx", notinhyps: ["a"], subst: {"x": "a"} } ] },
+    "∃I"  : { pred: true, forms: [ { prems: ["Aa"], conc: "∃xAx", subst: {"x":"a"} } ] },
+    "=I"  : { pred: true, forms: [ { conc: "c = c", prems: [] } ] },
+    "R"   : { forms: [ { prems: ["A"], conc: "A" } ], derived: true },
+    "∨E"  : { forms: [ { conc: "C", prems: ["A ∨ B"], subderivs: [ { needs: ["C"], allows: "A" }, { needs: ["C"], allows: "B" } ] } ] },
+    "∧E"  : { forms: [ { prems: ["A ∧ B"], conc: "A" }, { prems: ["A ∧ B"], conc: "B" } ] },
+    "→E"  : { forms: [ { prems: ["A → C", "A"], conc: "C" } ] },
+    "↔E"  : { forms: [ { prems: ["A ↔ B", "A"], conc: "B" }, { prems: ["A ↔ B", "B"], conc: "A" } ] },
+    "¬E"  : { forms: [ { prems: ["A", "¬A"], conc: "⊥" } ] },
+    "∀E"  : { pred: true, forms: [ { prems: ["∀xAx"], conc: "Aa", subst: {"x":"a"} } ] },
+    "∃E"  : { pred: true, forms: [ { conc: "B", prems: ["∃xAx"], notinhyps: ["n"], cannotbein: {"n":["Ax","B"]}, subst: {"x": "n"}, subderivs: [ { needs: ["B"], allows: "An" } ] } ] },
+    "=E"  : { pred: true, forms: [ { prems: ["a = b", "A"], conc: "B", differsatmostby: ["B","A","b","a"] }, { prems: ["a = b", "A"], conc: "B", differsatmostby: ["B","A","a","b"] } ] },
+    "MT"  : { forms: [ { prems: ["A → B", "¬B"], conc: "¬A" } ], derived: true },
+    "Pr"  : { premiserule: true, hidden: true },
+    "Hyp" : { assumptionrule: true, hidden: true }
+}
+
+allRules.adelaide = {
+    "¬I"  : { forms : [ { conc: "¬A", subderivs: [ { needs: ["B", "¬B"], allows: "A" } ] } ] },
+    "¬E"  : { forms : [ { conc: "A", subderivs: [ { needs: ["B", "¬B"], allows: "¬A" } ] } ] },
+    "DS"  : { forms: [ { prems: ["A ∨ B", "¬A"], conc: "B" }, { prems: ["A ∨ B", "¬B"], conc: "A" } ], derived: true },
+    "DNE" : { forms: [ { prems: ["¬¬A"], conc: "A" } ], derived: true },
+    "TND" : { forms: [ { conc: "B", subderivs: [ { needs: ["B"], allows: "A" }, { needs: ["B"], allows: "¬A" } ] } ] },
+    "DeM" : { forms: [ { prems: ["¬(A ∧ B)"], conc: "¬A ∨ ¬B" }, { prems: ["¬A ∨ ¬B"], conc: "¬(A ∧ B)" }, { prems: ["¬(A ∨ B)"], conc: "¬A ∧ ¬B" }, { prems: ["¬A ∧ ¬B"], conc: "¬(A ∨ B)" } ], derived: true },
+    "=E"  : { pred: true, forms: [ { prems: ["a = b", "A"], conc: "B", differsatmostby: ["B","A","b","a"] } ] },
+    "=ES" : { pred: true, forms: [ { prems: ["a = b", "A"], conc: "B", differsatmostby: ["B","A","a","b"] } ] }
+}
+
+allRules.bristol = {
+    "¬E"  : { meinongian: true, hint: "An elimination rule for negation does not exist in this system." },
+    "⊥I"  : { forms: [ { prems: ["A", "¬A"], conc: "⊥" } ] },
+    "⊥E"  : { forms: [ { prems: ["⊥"], conc: "A" } ] },
+    "PbC" : { forms: [ { conc: "A", subderivs: [ { needs: ["⊥"], allows: "¬A" } ] } ] },
+    "DS"  : { forms: [ { prems: ["A ∨ B", "¬A"], conc: "B" }, { prems: ["A ∨ B", "¬B"], conc: "A" } ], derived: true },
+    "LEM" : { forms: [ { conc: "B", subderivs: [ { needs: ["B"], allows: "A" }, { needs: ["B"], allows: "¬A" } ] } ], derived: true },
+    "DNE" : { forms: [ { prems: ["¬¬A"], conc: "A" } ], derived: true },
+    "DeM" : { forms: [ { prems: ["¬(A ∧ B)"], conc: "¬A ∨ ¬B" }, { prems: ["¬A ∨ ¬B"], conc: "¬(A ∧ B)" }, { prems: ["¬(A ∨ B)"], conc: "¬A ∧ ¬B" }, { prems: ["¬A ∧ ¬B"], conc: "¬(A ∨ B)" } ], derived: true },
+    "CQ"  : { pred: true, forms: [ { prems: ["∀x¬Ax"], conc: "¬∃xAx" }, { prems: ["∃x¬Ax"], conc: "¬∀xAx" }, { prems: ["¬∀xAx"], conc: "∃x¬Ax" }, { prems: ["¬∃xAx"], conc: "∀x¬Ax" } ], derived: true }
+}
+
+allRules.cambridge = {
+    "X"   : { forms: [ { prems: ["⊥"], conc: "A" } ] },
+    "TND" : { forms: [ { conc: "B", subderivs: [ { needs: ["B"], allows: "A" }, { needs: ["B"], allows: "¬A" } ] } ] },
+    "DS"  : { forms: [ { prems: ["A ∨ B", "¬A"], conc: "B" }, { prems: ["A ∨ B", "¬B"], conc: "A" } ], derived: true },
+    "DNE" : { forms: [ { prems: ["¬¬A"], conc: "A" } ], derived: true },
+    "DeM" : { forms: [ { prems: ["¬(A ∧ B)"], conc: "¬A ∨ ¬B" }, { prems: ["¬A ∨ ¬B"], conc: "¬(A ∧ B)" }, { prems: ["¬(A ∨ B)"], conc: "¬A ∧ ¬B" }, { prems: ["¬A ∧ ¬B"], conc: "¬(A ∨ B)" } ], derived: true },
+    "CQ"  : { pred: true, forms: [ { prems: ["∀x¬Ax"], conc: "¬∃xAx" }, { prems: ["∃x¬Ax"], conc: "¬∀xAx" }, { prems: ["¬∀xAx"], conc: "∃x¬Ax" }, { prems: ["¬∃xAx"], conc: "∀x¬Ax" } ], derived: true }
+}
+
+allRules.calgary = {
+    "IP"  : { forms: [ { conc: "A", subderivs: [ { needs: ["⊥"], allows: "¬A" } ] } ] },
+    "X"   : { forms: [ { prems: ["⊥"], conc: "A" } ] },
+    "DS"  : { forms: [ { prems: ["A ∨ B", "¬A"], conc: "B" }, { prems: ["A ∨ B", "¬B"], conc: "A" } ], derived: true },
+    "LEM" : { forms: [ { conc: "B", subderivs: [ { needs: ["B"], allows: "A" }, { needs: ["B"], allows: "¬A" } ] } ], derived: true },
+    "DNE" : { forms: [ { prems: ["¬¬A"], conc: "A" } ], derived: true },
+    "DeM" : { forms: [ { prems: ["¬(A ∧ B)"], conc: "¬A ∨ ¬B" }, { prems: ["¬A ∨ ¬B"], conc: "¬(A ∧ B)" }, { prems: ["¬(A ∨ B)"], conc: "¬A ∧ ¬B" }, { prems: ["¬A ∧ ¬B"], conc: "¬(A ∨ B)" } ], derived: true },
+    "CQ"  : { pred: true, forms: [ { prems: ["∀x¬Ax"], conc: "¬∃xAx" }, { prems: ["∃x¬Ax"], conc: "¬∀xAx" }, { prems: ["¬∀xAx"], conc: "∃x¬Ax" }, { prems: ["¬∃xAx"], conc: "∀x¬Ax" } ], derived: true }
+}
+
+allRules.loraincounty = {
+    "¬I"     : { forms : [ { conc: "¬A", subderivs: [ { needs: ["B", "¬B"], allows: "A" } ] } ] },
+    "∨E"     : { forms: [ { prems: ["A ∨ B", "¬A"], conc: "B" }, { prems: ["A ∨ B", "¬B"], conc: "A" } ] },
+    "¬E"     : { forms : [ { conc: "A", subderivs: [ { needs: ["B", "¬B"], allows: "¬A" } ] } ] },
+    "CD"     : { forms: [ { prems: ["A ∨ B", "A → C", "B -> C"], conc: "C" } ], derived: true },
+    "DD"     : { forms: [ { prems: ["A → B", "A → C", "¬B ∨ ¬C"], conc: "¬A" } ], derived: true },
+    "HS"     : { forms: [ { prems: ["A → B", "B → C"], conc: "A → C" } ], derived: true },
+    "DeM"    : { replacementrule: true, forms: [ { a: "¬(A ∨ B)", b: "¬A ∧ ¬ B" }, { a: "¬(A ∧ B)", b: "¬A ∨ ¬B" } ], derived: true },
+    "Idem∨"  : { forms: [ { prems: ["A ∨ A"], conc: "A" } ], derived: true },
+    "Idem∧"  : { forms: [ { prems: ["A"], conc: "A ∧ A" } ], derived: true },
+    "WK"     : { forms: [ { prems: ["A"], conc: "B → A" } ], derived: true },
+    "Comm∧"  : { replacementrule: true, forms: [ { a: "A ∧ B", b: "B ∧ A" } ], derived: true },
+    "Comm∨"  : { replacementrule: true, forms: [ { a: "A ∨ B", b: "B ∨ A" } ], derived: true },
+    "Comm↔"  : { replacementrule: true, forms: [ { a: "A ↔ B", b: "B ↔ A" } ], derived: true },
+    "DN"     : { replacementrule: true, forms: [ { a: "A", b: "¬¬A" } ], derived: true },
+    "MC"     : { replacementrule: true, forms: [ { a: "A → B", b: "¬A ∨ B" }, { a: "A ∨ B", b: "¬A → B" } ], derived: true },
+    "ex"     : { replacementrule: true, forms: [ { a: "(A → B) ∧ (B → A)", b: "A ↔ B" } ], derived: true },
+    "Trans"  : { replacementrule: true, forms: [ { a: "A → B", b: "¬B → ¬C" } ], derived: true },
+    "Assoc∧" : { replacementrule: true, forms: [ { a: "(A ∧ B) ∧ C", b: "A ∧ (B ∧ C)" } ], derived: true },
+    "Assoc∨" : { replacementrule: true, forms: [ { a: "(A ∨ B) ∨ C", b: "A ∨ (B ∨ C)" } ], derived: true },
+    "Assoc↔" : { replacementrule: true, forms: [ { a: "(A ↔ B) ↔ C", b: "A ↔ (B ↔ C)" } ], derived: true },
+    "QN"     : { replacementrule: true, forms: [ { a: "¬∀xAx", b: "∃x¬Ax" }, { a: "¬∃xAx", b: "∀x¬Ax" } ], derived: true, pred: true }
+}
+
+allRules.magnus = {
+    "¬I"   : { forms : [ { conc: "¬A", subderivs: [ { needs: ["B", "¬B"], allows: "A" } ] } ] },
+    "∨E"   : { forms: [ { prems: ["A ∨ B", "¬A"], conc: "B" }, { prems: ["A ∨ B", "¬B"], conc: "A" } ] },
+    "¬E"   : { forms : [ { conc: "A", subderivs: [ { needs: ["B", "¬B"], allows: "¬A" } ] } ] },
+    "DeM"  : { replacementrule: true, forms: [ { a: "¬(A ∨ B)", b: "¬A ∧ ¬ B" }, { a: "¬(A ∧ B)", b: "¬A ∨ ¬B" } ], derived: true },
+    "DIL"  : { forms: [ { prems: ["A ∨ B", "A → C", "B → C"], conc: "C" } ], derived: true },
+    "HS"   : { forms: [ { prems: ["A → B", "B → C"], conc: "A → C" } ], derived: true },
+    "Comm" : { replacementrule: true, forms: [ { a: "A ∧ B", b: "B ∧ A" }, { a: "A ∨ B", b: "B ∨ A" }, { a: "A ↔ B", b: "B ↔ A" } ], derived: true },
+    "DN"   : { replacementrule: true, forms: [ { a: "A", b: "¬¬A" } ], derived: true },
+    "MC"   : { replacementrule: true, forms: [ { a: "A → B", b: "¬A ∨ B" }, { a: "A ∨ B", b: "¬A → B" } ], derived: true },
+    "↔ex"  : { replacementrule: true, forms: [ { a: "(A → B) ∧ (B → A)", b: "A ↔ B" } ], derived: true },
+    "QN"   : { replacementrule: true, forms: [ { a: "¬∀xAx", b: "∃x¬Ax" }, { a: "¬∃xFx", b: "∀x¬Ax" } ], derived: true, pred: true }
+}
+
+allRules.msu = {
+    "↔I"  : { forms: [ { prems: ["A → B", "B → A"], conc: "A ↔ B" } ] },
+    "¬I"  : { forms : [ { conc: "¬A", subderivs: [ { needs: ["B", "¬B"], allows: "A" } ] } ] },
+    "∨E"  : { forms: [ { prems: ["A ∨ B", "¬A"], conc: "B" }, { prems: ["A ∨ B", "¬B"], conc: "A" } ] },
+    "¬E"  : { forms : [ { conc: "A", subderivs: [ { needs: ["B", "¬B"], allows: "¬A" } ] } ] },
+    "DN"  : { forms: [ { prems: ["A"], conc: "¬¬A" } ] },
+    "MT"  : { meinongian: true, hidden: true },
+    "Pr"  : { premiserule: true, hidden: true },
+    "PR"  : { premiserule: true, hidden: true },
+    "AS"  : { assumptionrule: true, hidden: true }
+}
+
+allRules.pitt = {
+    "⊥I"  : { forms: [ { prems: ["A", "¬A"], conc: "⊥" } ] },
+    "¬E"  : { forms: [ { conc: "A", subderivs: [ { needs: ["⊥"], allows: "¬A" } ] } ] },
+    "⊥E"  : { forms: [ { prems: ["⊥"], conc: "A" } ] },
+    "DS"  : { forms: [ { prems: ["A ∨ B", "¬A"], conc: "B" }, { prems: ["A ∨ B", "¬B"], conc: "A" } ], derived: true },
+    "LEM" : { forms: [ { conc: "B", subderivs: [ { needs: ["B"], allows: "A" }, { needs: ["B"], allows: "¬A" } ] } ], derived: true },
+    "DNE" : { forms: [ { prems: ["¬¬A"], conc: "A" } ], derived: true },
+    "DeM" : { forms: [ { prems: ["¬(A ∧ B)"], conc: "¬A ∨ ¬B" }, { prems: ["¬A ∨ ¬B"], conc: "¬(A ∧ B)" }, { prems: ["¬(A ∨ B)"], conc: "¬A ∧ ¬B" }, { prems: ["¬A ∧ ¬B"], conc: "¬(A ∨ B)" } ], derived: true },
+    "CQ"  : { pred: true, forms: [ { prems: ["∀x¬Ax"], conc: "¬∃xAx" }, { prems: ["∃x¬Ax"], conc: "¬∀xAx" }, { prems: ["¬∀xAx"], conc: "∃x¬Ax" }, { prems: ["¬∃xAx"], conc: "∀x¬Ax" } ], derived: true }
+}
+
+allRules.r3 = {
+    "¬I"   : { forms : [ { conc: "¬A", subderivs: [ { needs: ["B", "¬B"], allows: "A" } ] } ] },
+    "∨E"   : { forms: [ { prems: ["A ∨ B", "¬A"], conc: "B" }, { prems: ["A ∨ B", "¬B"], conc: "A" } ] },
+    "¬E"   : { forms : [ { conc: "A", subderivs: [ { needs: ["B", "¬B"], allows: "¬A" } ] } ] },
+    "DeM"  : { replacementrule: true, forms: [ { a: "¬(A ∨ B)", b: "¬A ∧ ¬ B" }, { a: "¬(A ∧ B)", b: "¬A ∨ ¬B" } ], derived: true },
+    "DIL"  : { forms: [ { prems: ["A ∨ B", "A → C", "B → C"], conc: "C" } ], derived: true },
+    "HS"   : { forms: [ { prems: ["A → B", "B → C"], conc: "A → C" } ], derived: true },
+    "Comm" : { replacementrule: true, forms: [ { a: "A ∧ B", b: "B ∧ A" }, { a: "A ∨ B", b: "B ∨ A" }, { a: "A ↔ B", b: "B ↔ A" } ], derived: true },
+    "DN"   : { replacementrule: true, forms: [ { a: "A", b: "¬¬A" } ], derived: true },
+    "MC"   : { replacementrule: true, forms: [ { a: "A → B", b: "¬A ∨ B" }, { a: "A ∨ B", b: "¬A → B" } ], derived: true },
+    "TAUT" : { replacementrule: true, forms: [ { a: "P ∨ P", b: "P" }, { a: "P ∧ P", b: "P" } ], derived: true },
+    "↔ex"  : { replacementrule: true, forms: [ { a: "(A → B) ∧ (B → A)", b: "A ↔ B" } ], derived: true },
+    "QN"   : { replacementrule: true, forms: [ { a: "¬∀xAx", b: "∃x¬Ax" }, { a: "¬∃xFx", b: "∀x¬Ax" } ], derived: true, pred: true }
+}
+
+allRules.slu = {
+    "⊥I"  : { forms: [ { prems: ["A", "¬A"], conc: "⊥" } ] },
+    "⊥E"  : { forms: [ { prems: ["⊥"], conc: "A" } ] },
+    "¬E"  : { meinongian: true, hint: "An elimination rule for negation does not exist in this system." },
+    "TND" : { forms: [ { conc: "B", subderivs: [ { needs: ["B"], allows: "A" }, { needs: ["B"], allows: "¬A" } ] } ] },
+    "DS"  : { forms: [ { prems: ["A ∨ B", "¬A"], conc: "B" }, { prems: ["A ∨ B", "¬B"], conc: "A" } ], derived: true },
+    "DNE" : { forms: [ { prems: ["¬¬A"], conc: "A" } ], derived: true },
+    "DeM" : { forms: [ { prems: ["¬(A ∧ B)"], conc: "¬A ∨ ¬B" }, { prems: ["¬A ∨ ¬B"], conc: "¬(A ∧ B)" }, { prems: ["¬(A ∨ B)"], conc: "¬A ∧ ¬B" }, { prems: ["¬A ∧ ¬B"], conc: "¬(A ∨ B)" } ], derived: true },
+    "CQ"  : { pred: true, forms: [ { prems: ["∀x¬Ax"], conc: "¬∃xAx" }, { prems: ["∃x¬Ax"], conc: "¬∀xAx" }, { prems: ["¬∀xAx"], conc: "∃x¬Ax" }, { prems: ["¬∃xAx"], conc: "∀x¬Ax" } ], derived: true }
+}
+
+allRules.ubc = {
+    "↔I"   : { forms: [ { conc: "A ↔ B", prems: [ "A → B", "B → A" ] } ] },
+    "¬I"   : { forms : [ { conc: "¬A", subderivs: [ { needs: ["B", "¬B"], allows: "A" } ] } ] },
+    "∨E"   : { forms: [ { prems: ["A ∨ B", "¬A"], conc: "B" }, { prems: ["A ∨ B", "¬B"], conc: "A" } ] },
+    "¬E"   : { forms : [ { conc: "A", subderivs: [ { needs: ["B", "¬B"], allows: "¬A" } ] } ] },
+    "DeM"  : { replacementrule: true, forms: [ { a: "¬(A ∨ B)", b: "¬A ∧ ¬ B" }, { a: "¬(A ∧ B)", b: "¬A ∨ ¬B" } ], derived: true },
+    "DIL"  : { forms: [ { prems: ["A ∨ B", "A → C", "B → C"], conc: "C" } ], derived: true },
+    "HS"   : { forms: [ { prems: ["A → B", "B → C"], conc: "A → C" } ], derived: true },
+    "Comm" : { replacementrule: true, forms: [ { a: "A ∧ B", b: "B ∧ A" }, { a: "A ∨ B", b: "B ∨ A" }, { a: "A ↔ B", b: "B ↔ A" } ], derived: true },
+    "DN"   : { replacementrule: true, forms: [ { a: "A", b: "¬¬A" } ], derived: true },
+    "MC"   : { replacementrule: true, forms: [ { a: "A → B", b: "¬A ∨ B" }, { a: "A ∨ B", b: "¬A → B" } ], derived: true },
+    "↔ex"  : { replacementrule: true, forms: [ { a: "(A → B) ∧ (B → A)", b: "A ↔ B" } ], derived: true },
+    "QN"   : { replacementrule: true, forms: [ { a: "¬∀xAx", b: "∃x¬Ax" }, { a: "¬∃xAx", b: "∀x¬Ax" } ], derived: true, pred: true }
+}
+
+allRules.leeds = allRules.magnus;
+allRules.uconn = allRules.calgary;
+
+function substituteSymbols(s, notationname) {
+    const innotation = notations["cambridge"];
+    const outnotation = notations[notationname];
+    for (const op of opnames) {
+        s = s.replaceAll(innotation[op], outnotation[op]);
+    }
+    return s;
+}
+
+export default function getForallxRules(rulesetname, notationname = null) {
+    // rulesetname same as notationname unless specified
+    if (notationname === null) {
+        notationname = rulesetname;
+    }
+    const comboname = rulesetname + '--' + notationname;
+    if (comboname in rulesrepository) {
+        return rulesrepository[comboname];
+    }
+
+    // start with common rules; but copy them to allow multiple of
+    // same base
+    const ruleset = JSON.parse(JSON.stringify(allRules.common));
+    // add other rules if need be
+    if (rulesetname in allRules) {
+        // make a copy to avoid messing up if multiple on same page
+        const rulestoadd = JSON.parse(JSON.stringify(allRules[rulesetname]));
+        for (const rule in rulestoadd) {
+            ruleset[rule] = rulestoadd[rule];
+        }
+    }
+    // don't bother with notation change if we are just returning the same
+    if (['cambridge','calgary','slu','pitt','adelaide','uconn'].indexOf(notationname) >= 0) {
+        rulesrepository[comboname] = ruleset;
+        return ruleset;
+    }
+    // bind change function to new notation
+    const change = ((s) => (substituteSymbols(s, notationname)));
+    // start a new rule set and populate with changed rules
+    const newruleset = {};
+    for (const rulename in ruleset) {
+        const newrulename = change(rulename);
+        const rule = ruleset[rulename];
+        if ("forms" in rule) {
+            for (const form of rule.forms) {
+                if ("conc" in form) {
+                    form.conc = change(form.conc);
+                }
+                if ("prems" in form) {
+                    for (let i=0; i<form.prems.length; i++) {
+                        form.prems[i] = change(form.prems[i]);
+                    }
+                }
+                if ("a" in form) {
+                    form.a = change(form.a);
+                }
+                if ("b" in form) {
+                    form.b = change(form.b);
+                }
+                if ("subderivs" in form) {
+                    for (const subderiv of form.subderivs) {
+                        if ("needs" in subderiv) {
+                            for (let i=0; i<subderiv.needs.length; i++) {
+                                subderiv.needs[i] = change(subderiv.needs[i]);
+                            }
+                        }
+                        if ("allows" in subderiv) {
+                            subderiv.allows = change(subderiv.allows);
+                        }
+                    }
+                }
+            }
+        }
+        newruleset[newrulename] = rule;
+    }
+    rulesrepository[comboname] = newruleset;
+    return newruleset;
+}

--- a/lib/logicpenguin/checkers/rules/forallx-rules.js
+++ b/lib/logicpenguin/checkers/rules/forallx-rules.js
@@ -75,6 +75,8 @@ allRules.cambridge = {
 }
 
 allRules.calgary = {
+    "PR"  : { premiserule: true, hidden: true },
+    "AS"  : { assumptionrule: true, hidden: true },
     "IP"  : { forms: [ { conc: "A", subderivs: [ { needs: ["⊥"], allows: "¬A" } ] } ] },
     "X"   : { forms: [ { prems: ["⊥"], conc: "A" } ] },
     "DS"  : { forms: [ { prems: ["A ∨ B", "¬A"], conc: "B" }, { prems: ["A ∨ B", "¬B"], conc: "A" } ], derived: true },

--- a/lib/logicpenguin/problemtypes/derivation-base.js
+++ b/lib/logicpenguin/problemtypes/derivation-base.js
@@ -128,8 +128,9 @@ export default class DerivationExercise extends LogicPenguinProblem {
             }
         };
 
-        // assign notation, symbols, syntax
-        this.syntax = getSyntax();
+        // use the active notation
+        this.notationname = options?.notation ?? 'calgary';
+        this.syntax = getSyntax(this.notationname);
         this.symbols = this.syntax.symbols;
         this.notation = this.syntax.notation;
 

--- a/lib/logicpenguin/symbolic/formula.js
+++ b/lib/logicpenguin/symbolic/formula.js
@@ -10,9 +10,9 @@
 import getSyntax from './libsyntax.js';
 import { arrayUnion } from '../misc.js';
 
-let cachedFormulaClass = null;
+const formulaClasses = {};
 
-function generateFormulaClass() {
+function generateFormulaClass(notationname = 'hurley') {
     class Formula {
 
         // start by recording what string got parsed
@@ -28,7 +28,7 @@ function generateFormulaClass() {
         // having to redo work that was already done
         static repository = {};
 
-        static syntax = getSyntax();
+        static syntax = getSyntax(notationname);
 
         // main function for fetching from the repository or adding to it
         // if necessary
@@ -809,10 +809,10 @@ function generateFormulaClass() {
 
 // main function, either retrieves a Formula class from those
 // already generated, or generates a new one and returns it
-export default function getFormulaClass() {
-    if (cachedFormulaClass) {
-        return cachedFormulaClass;
+export default function getFormulaClass(notationname = 'hurley') {
+    if (formulaClasses[notationname]) {
+        return formulaClasses[notationname];
     }
-    cachedFormulaClass = generateFormulaClass();
-    return cachedFormulaClass;
+    formulaClasses[notationname] = generateFormulaClass(notationname);
+    return formulaClasses[notationname];
 }

--- a/lib/logicpenguin/symbolic/libsemantics.js
+++ b/lib/logicpenguin/symbolic/libsemantics.js
@@ -49,12 +49,12 @@ libtf.allinterps = function(wffs) {
 
 // evaluates a formula on an interpretation; keeping track of the
 // "full truth table row" and where the main op is in it
-libtf.evaluate = function(wff, interp) {
-    const syntax = getSyntax();
+libtf.evaluate = function(wff, interp, notation = undefined) {
+    const syntax = getSyntax(notation);
     const tfn = (wff.op) ? libtf.tfns[syntax.operators[wff.op]] : false;
     if (syntax.isbinaryop(wff.op)) {
-        const lres = libtf.evaluate(wff.left, interp);
-        const rres = libtf.evaluate(wff.right, interp);
+        const lres = libtf.evaluate(wff.left, interp, notation);
+        const rres = libtf.evaluate(wff.right, interp, notation);
         const tv = tfn(lres.tv, rres.tv);
         return {
             tv: tv,
@@ -63,7 +63,7 @@ libtf.evaluate = function(wff, interp) {
         }
     }
     if (syntax.ismonop(wff.op)) {
-        const rres = libtf.evaluate(wff.right, interp);
+        const rres = libtf.evaluate(wff.right, interp, notation);
         const tv = tfn(rres.tv)
         return { tv: tv, row: [tv, ...rres.row], opspot: 0 }
     }
@@ -74,13 +74,13 @@ libtf.evaluate = function(wff, interp) {
 
 // fills in a truth table for one formula and determines if it
 // is a contradiction or tautology
-export function formulaTable(fml) {
+export function formulaTable(fml, notation = undefined) {
     const interps = libtf.allinterps([fml]);
     let taut = true;
     let contra = true;
     let opspot = 0;
     const rows = interps.map( (interp) => {
-        const e = libtf.evaluate(fml, interp);
+        const e = libtf.evaluate(fml, interp, notation);
         if (e.tv) { contra = false; } else { taut = false; }
         opspot = e.opspot;
         return e.row;
@@ -90,7 +90,7 @@ export function formulaTable(fml) {
 
 // fills in truth table for two formulas and checks their
 // equivalence
-export function equivTables(fmlA, fmlB) {
+export function equivTables(fmlA, fmlB, notation = undefined) {
     const interps = libtf.allinterps([fmlA,fmlB]);
     let equiv = true;
     const A = {};
@@ -100,8 +100,8 @@ export function equivTables(fmlA, fmlB) {
     A.rows = [];
     B.rows = [];
     for (const interp of interps) {
-        const ea = libtf.evaluate(fmlA, interp);
-        const eb = libtf.evaluate(fmlB, interp);
+        const ea = libtf.evaluate(fmlA, interp, notation);
+        const eb = libtf.evaluate(fmlB, interp, notation);
         A.opspot = ea.opspot;
         B.opspot = eb.opspot;
         A.rows.push(ea.row);
@@ -113,7 +113,7 @@ export function equivTables(fmlA, fmlB) {
 
 // fills in the truth tables for the premises and conclusion of
 // an argument and determines its validity
-export function argumentTables(pwffs, cwff) {
+export function argumentTables(pwffs, cwff, notation = undefined) {
 
     const interps = libtf.allinterps([...pwffs,cwff]);
     let valid = true;
@@ -128,12 +128,12 @@ export function argumentTables(pwffs, cwff) {
         let allpremstrue = true;
         for (let i=0; i < pwffs.length; i++) {
             const w = pwffs[i];
-            const e = libtf.evaluate(w, interp);
+            const e = libtf.evaluate(w, interp, notation);
             prems[i].opspot = e.opspot;
             prems[i].rows.push(e.row);
             allpremstrue = (allpremstrue && e.tv);
         }
-        const ce = libtf.evaluate(cwff, interp);
+        const ce = libtf.evaluate(cwff, interp, notation);
         conc.opspot = ce.opspot;
         conc.rows.push(ce.row);
         valid = (valid && (!allpremstrue || ce.tv));
@@ -143,11 +143,11 @@ export function argumentTables(pwffs, cwff) {
 
 // fills in truth tables for multiple formulas using shared interpretations
 // returns rows per subformula column (atoms first, then derived, then main)
-export function multiTables(wffs) {
+export function multiTables(wffs, notation = undefined) {
     const interps = libtf.allinterps(wffs);
     const tables = [];
 
-    const syntax = getSyntax();
+    const syntax = getSyntax(notation);
 
     // evaluation aligned with column order: left subformula(s), operator, right subformula(s)
     function evalWithTokens(wff, interp) {
@@ -197,7 +197,7 @@ export function multiTables(wffs) {
 
 // determines truth tables for a problem in which the student
 // did their own translations and determines validity
-export function comboTables(wffs, index) {
+export function comboTables(wffs, index, notation = undefined) {
     const tables = [];
     const interps = libtf.allinterps(wffs);
     let valid = true;
@@ -209,7 +209,7 @@ export function comboTables(wffs, index) {
         let conctrue = false;
         for (let i=0; i<wffs.length; i++) {
             const wff=wffs[i];
-            const e = libtf.evaluate(wff, interp);
+            const e = libtf.evaluate(wff, interp, notation);
             tables[i].opspot = e.opspot;
             tables[i].rows.push(e.row);
             if (i==index) { // conclusion

--- a/lib/logicpenguin/symbolic/libsyntax.js
+++ b/lib/logicpenguin/symbolic/libsyntax.js
@@ -85,22 +85,34 @@ function mkexistential(v) {
     return this.mkquantifier(v, this.symbols.EXISTS);
 }
 
+function symbolfix(s) {
+    let rv = String(s ?? '');
+
+    rv = rv.replace(/-->/g, this.symbols.IFTHEN);
+    rv = rv.replace(/<->/g, this.symbols.IFF);
+    rv = rv.replace(/<–>/g, this.symbols.IFF);
+    rv = rv.replace(/<=>/g, this.symbols.IFF);
+    rv = rv.replace(/->/g, this.symbols.IFTHEN);
+    rv = rv.replace(/–>/g, this.symbols.IFTHEN);
+    rv = rv.replace(/=>/g, this.symbols.IFTHEN);
+    rv = rv.replace(/>/g, this.symbols.IFTHEN);
+    rv = rv.replace(/\/\\/g, this.symbols.AND);
+    rv = rv.replace(/\\\//g, this.symbols.OR);
+    rv = rv.replace(/[&^∧•·]/g, this.symbols.AND);
+    rv = rv.replace(/[|]/g, this.symbols.OR);
+    rv = rv.replace(/[↔≡]/g, this.symbols.IFF);
+    rv = rv.replace(/[→⇒⊃]/g, this.symbols.IFTHEN);
+    rv = rv.replace(/[~¬]/g, this.symbols.NOT);
+    rv = rv.replace(/[⊥✖]/g, this.symbols.FALSUM);
+    return rv;
+}
+
 // changes to input string you'd be all right applying even to
 // input fields, here we remove redundant spaces
 function inputfix(s) {
-    // remove spaces
-    let rv = s.replace(/\s/g,'');
-    
-    
-    // convert plaintext shorthands to Hurley's notation
-    rv = rv.replace(/-->/g, this.symbols.IFTHEN);
-    rv = rv.replace(/->/g, this.symbols.IFTHEN);
-    if (this.symbols.AND != '&') {
-        rv = rv.replace(/&/g, this.symbols.AND);
-    }
-    if (this.symbols.AND != '^') {
-        rv = rv.replace(/\^/g, this.symbols.AND);
-    }
+    // remove spaces and convert plaintext shorthands to the active notation
+    let rv = this.symbolfix(String(s ?? '').replace(/\s/g,''));
+
     // accept lowercase "v" as a disjunction when used infix (e.g., CvM -> C∨M)
     rv = rv.replace(/([A-Za-z)\]\}])v([A-Za-z(\[\{])/g, `$1${this.symbols.OR}$2`);
     rv = rv.replace(/\ball\b/gi, this.symbols.FORALL); // 'all' becomes ∀
@@ -213,6 +225,7 @@ function generateSyntax(notationname = DEFAULT_NOTATION) {
     syntax.ncRegEx = new RegExp( '[^' + syntax.notation.constantsRange + ']', 'g');
 
     // BIND SYNTAX FUNCTIONS TO THIS SYNTAX
+    syntax.symbolfix = symbolfix;
     syntax.inputfix = inputfix;
     syntax.isbinaryop = isbinaryop;
     syntax.ismonop = ismonop;

--- a/lib/logicpenguin/symbolic/libsyntax.js
+++ b/lib/logicpenguin/symbolic/libsyntax.js
@@ -10,7 +10,7 @@
 import notations from './notations.js';
 
 const DEFAULT_NOTATION = 'hurley';
-let cachedSyntax = null;
+const syntaxes = {};
 
 // adicities for operators
 const symbolcat = {
@@ -153,12 +153,12 @@ function stripmatching(s) {
 }
 
 //////////// Main function for generating new syntax
-function generateSyntax() {
+function generateSyntax(notationname = DEFAULT_NOTATION) {
     // initialize return value
     const syntax = {};
 
-    syntax.notation = notations[DEFAULT_NOTATION];
-    syntax.notationname = DEFAULT_NOTATION;
+    syntax.notationname = notationname in notations ? notationname : DEFAULT_NOTATION;
+    syntax.notation = notations[syntax.notationname];
 
     // symbols are those things in notation also in symbolcat
     const symbols = {}
@@ -231,13 +231,11 @@ function generateSyntax() {
 // EXPORTED FUNCTION
 //
 // returns the app's (single) syntax object
-export default function getSyntax() {
-    if (cachedSyntax) {
-        // regenerate if notation has changed (e.g., updated ranges)
-        if (cachedSyntax?.notation?.predicatesRange?.includes('a')) {
-            return cachedSyntax;
-        }
+export default function getSyntax(notationname = DEFAULT_NOTATION) {
+    const selectedNotation = notationname in notations ? notationname : DEFAULT_NOTATION;
+    if (syntaxes[selectedNotation]) {
+        return syntaxes[selectedNotation];
     }
-    cachedSyntax = generateSyntax();
-    return cachedSyntax;
+    syntaxes[selectedNotation] = generateSyntax(selectedNotation);
+    return syntaxes[selectedNotation];
 }

--- a/lib/logicpenguin/symbolic/notations.js
+++ b/lib/logicpenguin/symbolic/notations.js
@@ -3,10 +3,26 @@
 // https://www.gnu.org/licenses/.
 
 ////////////////// notations.js ///////////////////////////
-// This app uses a single notation: Hurley.           //
+// This app supports the course notation selected by logic_system. //
 ///////////////////////////////////////////////////////////
 
 const notations = {
+    calgary: {
+        OR      : '∨',
+        AND     : '∧',
+        IFTHEN  : '→',
+        IFF     : '↔',
+        NOT     : '¬',
+        FORALL  : '∀',
+        EXISTS  : '∃',
+        FALSUM  : '⊥',
+        constantsRange: 'a-r',
+        predicatesRange: '=≠A-Z',
+        quantifierForm: 'Qx',
+        schematicLetters: '𝒜𝒜𝓍𝒸𝒸',
+        useTermParensCommas: true,
+        variableRange: 'x-zs-w'
+    },
     hurley: {
         OR      : '∨',
         AND     : '•',

--- a/models/Course.js
+++ b/models/Course.js
@@ -1,4 +1,5 @@
 import { DataTypes, Model } from 'sequelize';
+import { DEFAULT_LOGIC_SYSTEM, LOGIC_SYSTEMS } from '../lib/logicSystems.js';
 
 export default function initCourse(sequelize) {
   class Course extends Model {}
@@ -21,6 +22,14 @@ export default function initCourse(sequelize) {
       title: {
         type: DataTypes.STRING,
         allowNull: false,
+      },
+      logic_system: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        defaultValue: DEFAULT_LOGIC_SYSTEM,
+        validate: {
+          isIn: [Object.keys(LOGIC_SYSTEMS)],
+        },
       },
       is_active: {
         type: DataTypes.BOOLEAN,

--- a/routes/validate.js
+++ b/routes/validate.js
@@ -6,10 +6,12 @@ import {
   AssignmentExtension,
   AssignmentQuestionOverride,
   Accommodation,
+  Course,
   CourseEnrollment,
   Submission,
 } from '../models/index.js';
 import { validateLogicPenguin } from '../validators/logicpenguin.js';
+import { LEGACY_LOGIC_SYSTEM, normalizeLogicSystem } from '../lib/logicSystems.js';
 import { computeDeadlinePolicy } from '../utils/assignmentPolicy.js';
 import { recomputeAssignmentGrade, ensureZeroGradesForPastDue, ensureZeroGradesForUnlocked } from '../utils/grades.js';
 import { handleValidationResult } from '../middleware/validation.js';
@@ -33,8 +35,6 @@ router.post(
       attempt,
       user_id,
       submission_data,
-      notation,
-      ruleset,
       validation_version,
     } = req.body;
     if (!ensureSelfOrAdmin(req, res, user_id)) {
@@ -44,7 +44,7 @@ router.post(
     // require fields that are definitely needed to accept a submission
     // load the question and its assignment for policy checks
     const assignmentQuestion = await AssignmentQuestion.findByPk(assignment_question_id, {
-      include: [{ model: Assignment }],
+      include: [{ model: Assignment, include: [{ model: Course, attributes: ['id', 'logic_system'] }] }],
     });
 
     // 404
@@ -118,8 +118,12 @@ router.post(
       return res.status(400).json({ message: `Next attempt must be ${nextAttempt}` });
     }
 
-    // validator options from the question snapshot + request overrides
+    // validator options from the course and question snapshot
     const questionSnapshot = assignmentQuestion.question_snapshot || {};
+    const logicSystem = normalizeLogicSystem(
+      assignmentQuestion.Assignment?.Course?.logic_system,
+      LEGACY_LOGIC_SYSTEM
+    );
     const snapshotPartial =
       questionSnapshot.partialCredit ??
       questionSnapshot.partialcredit ??
@@ -135,8 +139,7 @@ router.post(
       questionSnapshot.truth_table?.options?.partial_credit ??
       false;
     const options = {
-      notation: notation || questionSnapshot.notation || 'hurley',
-      ruleset: ruleset || questionSnapshot.ruleset || 'hurley_default',
+      logicSystem,
       partialcredit: Boolean(snapshotPartial),
     };
 

--- a/utils/autoSubmit.js
+++ b/utils/autoSubmit.js
@@ -3,10 +3,12 @@ import {
   AssignmentExtension,
   AssignmentQuestion,
   Accommodation,
+  Course,
   CourseEnrollment,
   Submission,
 } from '../models/index.js';
 import { validateLogicPenguin } from '../validators/logicpenguin.js';
+import { LEGACY_LOGIC_SYSTEM, normalizeLogicSystem } from '../lib/logicSystems.js';
 import { computeDeadlinePolicy } from './assignmentPolicy.js';
 import { recomputeAssignmentGrade } from './grades.js';
 
@@ -42,6 +44,10 @@ export async function autoSubmitIfPastDeadline(assignment, userId) {
   const questions = await AssignmentQuestion.findAll({
     where: { assignment_id: assignment.id },
   });
+  const course = assignment.Course || await Course.findByPk(assignment.course_id, {
+    attributes: ['id', 'logic_system'],
+  });
+  const logicSystem = normalizeLogicSystem(course?.logic_system, LEGACY_LOGIC_SYSTEM);
 
   const created = [];
 
@@ -63,8 +69,7 @@ export async function autoSubmitIfPastDeadline(assignment, userId) {
 
     const questionSnapshot = question.question_snapshot || {};
     const options = {
-      notation: questionSnapshot.notation || 'hurley',
-      ruleset: questionSnapshot.ruleset || 'hurley_default',
+      logicSystem,
       partialcredit: questionSnapshot.partialCredit || false,
     };
 

--- a/validators/logicpenguin.js
+++ b/validators/logicpenguin.js
@@ -376,7 +376,7 @@ function computeTruthAnswer(question, options) {
   if (kind === 'equivalence') {
     const left = Formula.from(truthTable.left);
     const right = Formula.from(truthTable.right);
-    return equivTables(left, right);
+    return equivTables(left, right, notation);
   }
 
   if (kind === 'argument') {
@@ -394,7 +394,7 @@ function computeEvaluateTruthAnswer(question, options) {
   const statement = question.evaluateTruth || question.statement;
   const interpretation = question.interpretation || {};
   const f = Formula.from(statement);
-  const result = libtf.evaluate(f, interpretation);
+  const result = libtf.evaluate(f, interpretation, notation);
   return Boolean(result.tv);
 }
 
@@ -404,7 +404,7 @@ function computeSingleRowTruthTableAnswer(question, options) {
   const statement = question.statement || question.evaluateTruth;
   const interpretation = question.interpretation || {};
   const f = Formula.from(statement);
-  const result = libtf.evaluate(f, interpretation);
+  const result = libtf.evaluate(f, interpretation, notation);
   return {
     row: result.row,
     opspot: result.opspot,

--- a/validators/logicpenguin.js
+++ b/validators/logicpenguin.js
@@ -331,17 +331,11 @@ function normalizeType(question) {
   return question?.type || question?.problemType || question?.logic_problem_type || 'derivation';
 }
 
-function isDerivationType(type) {
-  return type === 'derivation'
-    || type === 'derivation-hurley'
-    || type === 'derivation-calgary';
-}
-
 function resolveCheckerKey(type, question, options) {
   if (type === 'truth-table') {
     return `${question.truthTable?.kind || 'formula'}-truth-table`;
   }
-  if (options?.logicSystem && isDerivationType(type)) {
+  if (options?.logicSystem && type === 'derivation') {
     return getDerivationProblemType(options.logicSystem, 'hurley');
   }
   return type;
@@ -486,6 +480,7 @@ export async function validateLogicPenguin({
   points,
   options = {},
 }) {
+  const type = normalizeType(question);
   const mergedOptions = {
     ...options,
     ...(question?.options || {}),
@@ -494,13 +489,18 @@ export async function validateLogicPenguin({
   };
   if (options.logicSystem) {
     mergedOptions.logicSystem = options.logicSystem;
-    mergedOptions.notation = getLogicSystem(options.logicSystem, 'hurley').derivationSystem;
+    if (type === 'derivation-hurley') {
+      mergedOptions.notation = 'hurley';
+    } else if (type === 'derivation-calgary') {
+      mergedOptions.notation = 'calgary';
+    } else {
+      mergedOptions.notation = getLogicSystem(options.logicSystem, 'hurley').derivationSystem;
+    }
     delete mergedOptions.ruleset;
   }
   const partialcredit = Boolean(
     mergedOptions.partialcredit ?? mergedOptions.partialCredit ?? mergedOptions.partial_credit
   );
-  const type = normalizeType(question);
   const checkerKey = resolveCheckerKey(type, question, mergedOptions);
   const checker = CHECKERS[checkerKey];
   const normalizedQuestion = {

--- a/validators/logicpenguin.js
+++ b/validators/logicpenguin.js
@@ -16,6 +16,7 @@ import partialTruthTable from '../lib/logicpenguin/checkers/partial-truth-table.
 import nonclassicalTruthTable from '../lib/logicpenguin/checkers/nonclassical-truth-table.js';
 import getFormulaClass from '../lib/logicpenguin/symbolic/formula.js';
 import { formulaTable, equivTables, argumentTables, libtf } from '../lib/logicpenguin/symbolic/libsemantics.js';
+import { getDerivationProblemType, getLogicSystem } from '../lib/logicSystems.js';
 
 const CHECKERS = {
   derivation: derivationHurley,
@@ -330,6 +331,22 @@ function normalizeType(question) {
   return question?.type || question?.problemType || question?.logic_problem_type || 'derivation';
 }
 
+function isDerivationType(type) {
+  return type === 'derivation'
+    || type === 'derivation-hurley'
+    || type === 'derivation-calgary';
+}
+
+function resolveCheckerKey(type, question, options) {
+  if (type === 'truth-table') {
+    return `${question.truthTable?.kind || 'formula'}-truth-table`;
+  }
+  if (options?.logicSystem && isDerivationType(type)) {
+    return getDerivationProblemType(options.logicSystem, 'hurley');
+  }
+  return type;
+}
+
 function buildDerivationFromLines(proof) {
   const parts = (proof?.lines || []).map((line) => {
     const refs = Array.isArray(line.refs) ? line.refs : [];
@@ -475,13 +492,16 @@ export async function validateLogicPenguin({
     ...(question?.truthTable?.options || {}),
     ...(question?.truth_table?.options || {}),
   };
+  if (options.logicSystem) {
+    mergedOptions.logicSystem = options.logicSystem;
+    mergedOptions.notation = getLogicSystem(options.logicSystem, 'hurley').derivationSystem;
+    delete mergedOptions.ruleset;
+  }
   const partialcredit = Boolean(
     mergedOptions.partialcredit ?? mergedOptions.partialCredit ?? mergedOptions.partial_credit
   );
   const type = normalizeType(question);
-  const checkerKey = type === 'truth-table'
-    ? `${question.truthTable?.kind || 'formula'}-truth-table`
-    : type;
+  const checkerKey = resolveCheckerKey(type, question, mergedOptions);
   const checker = CHECKERS[checkerKey];
   const normalizedQuestion = {
     ...question,

--- a/validators/logicpenguin.js
+++ b/validators/logicpenguin.js
@@ -1,4 +1,5 @@
 import derivationHurley from '../lib/logicpenguin/checkers/derivation-hurley.js';
+import derivationCalgary from '../lib/logicpenguin/checkers/derivation-calgary.js';
 import formulaTruthTable from '../lib/logicpenguin/checkers/formula-truth-table.js';
 import equivalenceTruthTable from '../lib/logicpenguin/checkers/equivalence-truth-table.js';
 import argumentTruthTable from '../lib/logicpenguin/checkers/argument-truth-table.js';
@@ -19,6 +20,7 @@ import { formulaTable, equivTables, argumentTables, libtf } from '../lib/logicpe
 const CHECKERS = {
   derivation: derivationHurley,
   'derivation-hurley': derivationHurley,
+  'derivation-calgary': derivationCalgary,
   'formula-truth-table': formulaTruthTable,
   'equivalence-truth-table': equivalenceTruthTable,
   'argument-truth-table': argumentTruthTable,
@@ -280,7 +282,7 @@ function normalizeSubmissionByType({ checkerKey, submission, question }) {
   if (checkerKey === 'symbolic-translation') {
     return normalizeSymbolicSubmission(submission);
   }
-  if (checkerKey === 'derivation' || checkerKey === 'derivation-hurley') {
+  if (checkerKey === 'derivation' || checkerKey === 'derivation-hurley' || checkerKey === 'derivation-calgary') {
     return normalizeDerivationSubmission(submission);
   }
   if (checkerKey === 'true-false' || checkerKey === 'evaluate-truth') {


### PR DESCRIPTION
## 📝 Description

Adds  routing for multiple logic systems in validation/checking paths:

- adds a logic system registry for Fitch and Hurley
- adds `logic_system` to the Sequelize `Course` model with Fitch as the model default
- routes submission validation through the assignment course’s `logic_system`
- passes derivation validation to the active system’s derivation checker
- adds a Calgary/Fitch derivation checker & ruleset support
- keeps Hurley derivation validation paths available for existing Hurley snapshots
- routes truth table, evaluate-truth, single-row truth table, partial truth table, and combo truth-table parsing/evaluation through active notation

## 🚀 Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [x] 🛠️ Refactor / Chore (Code cleanup, dependency update, etc.)

## 🧪 How to Test

[Provide clear steps for the reviewer to manually test your UI or API changes.]

1. Pull down this branch
2. Confirm the database already has a `courses.logic_system` column before running the app
3. Run `npm test -- __tests__/derivation-calgary.test.js`
4. Submit an existing Hurley derivation and confirm it still uses the Hurley path
5. Submit a generic derivation in a Fitch course and confirm backend validation selects the Calgary/Fitch checker
6. Validate Hurley and Fitch/Calgary truth table submissions and confirm parsing follows the course notation

## ✅ Pre-Merge Checklist

- [x] I have performed a self-review of my own code.
- [x] I have removed all temporary `console.log`s and debuggers.
- [x] I have successfully rebased / resolved any merge conflicts with `main`.
- [x] UI looks good on both desktop and mobile viewports.
