### PR TITLE
instructor textbook management

### DIFF
--- a/__tests__/course-assignment-auth.test.js
+++ b/__tests__/course-assignment-auth.test.js
@@ -23,6 +23,16 @@ jest.unstable_mockModule('../models/index.js', () => ({
   AssignmentQuestionOverride: { findAll: jest.fn() },
   Accommodation: { findOne: jest.fn() },
   CourseEnrollment: { findOne: courseEnrollmentFindOne },
+  CourseTextbookStructure: {
+    findByPk: jest.fn(),
+    upsert: jest.fn(),
+    destroy: jest.fn(),
+  },
+  CourseTextbookPracticeLinks: {
+    findByPk: jest.fn(),
+    upsert: jest.fn(),
+    destroy: jest.fn(),
+  },
   Submission: { findAll: submissionFindAll },
   User: {},
   sequelize: { fn: sequelizeFn, col: sequelizeCol },

--- a/__tests__/textbook.routes.test.js
+++ b/__tests__/textbook.routes.test.js
@@ -1,0 +1,199 @@
+import { jest } from '@jest/globals';
+import errorHandler from '../middleware/error-handler.js';
+
+const courseEnrollmentFindOne = jest.fn();
+const structureFindByPk = jest.fn();
+const structureUpsert = jest.fn();
+const structureDestroy = jest.fn();
+const linksFindByPk = jest.fn();
+const linksUpsert = jest.fn();
+const linksDestroy = jest.fn();
+const requireInstructorOrAdmin = jest.fn();
+
+jest.unstable_mockModule('../models/index.js', () => ({
+  Course: {},
+  Assignment: {},
+  AssignmentDraft: {},
+  AssignmentExtension: { findOne: jest.fn() },
+  AssignmentGrade: {},
+  AssignmentQuestion: {},
+  AssignmentQuestionOverride: {},
+  Accommodation: { findOne: jest.fn() },
+  CourseEnrollment: { findOne: courseEnrollmentFindOne },
+  CourseTextbookStructure: {
+    findByPk: structureFindByPk,
+    upsert: structureUpsert,
+    destroy: structureDestroy,
+  },
+  CourseTextbookPracticeLinks: {
+    findByPk: linksFindByPk,
+    upsert: linksUpsert,
+    destroy: linksDestroy,
+  },
+  Submission: {},
+  User: {},
+  sequelize: { query: jest.fn(), fn: jest.fn(), col: jest.fn() },
+}));
+
+jest.unstable_mockModule('../routes/instructor.js', () => ({
+  requireInstructorOrAdmin,
+}));
+
+const coursesRouter = (await import('../routes/courses.js')).default;
+
+const getRouteHandlers = (router, path, method) => {
+  const layer = router.stack.find(
+    (entry) => entry.route?.path === path && entry.route.methods[method]
+  );
+  if (!layer) {
+    throw new Error(`route not found: ${method.toUpperCase()} ${path}`);
+  }
+  return layer.route.stack.map((entry) => entry.handle);
+};
+
+const createRes = () => ({
+  statusCode: 200,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+const runHandlers = async (handlers, req, res) => {
+  let index = 0;
+  let error = null;
+
+  while (index < handlers.length && !error) {
+    const handler = handlers[index];
+    let nextCalled = false;
+
+    await handler(req, res, (err) => {
+      nextCalled = true;
+      if (err) {
+        error = err;
+      } else {
+        index += 1;
+      }
+    });
+
+    if (!nextCalled) {
+      break;
+    }
+  }
+
+  if (error) {
+    await errorHandler(error, req, res, () => {});
+  }
+
+  return res;
+};
+
+describe('textbook course routes', () => {
+  beforeEach(() => {
+    courseEnrollmentFindOne.mockReset();
+    structureFindByPk.mockReset();
+    structureUpsert.mockReset();
+    structureDestroy.mockReset();
+    linksFindByPk.mockReset();
+    linksUpsert.mockReset();
+    linksDestroy.mockReset();
+    requireInstructorOrAdmin.mockReset();
+  });
+
+  test('GET textbook-structure requires enrollment', async () => {
+    courseEnrollmentFindOne.mockResolvedValue(null);
+    const handlers = getRouteHandlers(coursesRouter, '/:id/textbook-structure', 'get');
+    const res = await runHandlers(
+      handlers,
+      { params: { id: 3 }, user: { id: 9 } },
+      createRes()
+    );
+    expect(res.statusCode).toBe(403);
+  });
+
+  test('GET textbook-structure returns defaults when missing', async () => {
+    courseEnrollmentFindOne.mockResolvedValue({ role: 'student' });
+    structureFindByPk.mockResolvedValue(null);
+    const handlers = getRouteHandlers(coursesRouter, '/:id/textbook-structure', 'get');
+    const res = await runHandlers(
+      handlers,
+      { params: { id: 3 }, user: { id: 9 } },
+      createRes()
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      courseId: 3,
+      nodes: null,
+      usingDefaults: true,
+      updatedAt: null,
+    });
+  });
+
+  test('PUT textbook-structure requires instructor', async () => {
+    requireInstructorOrAdmin.mockResolvedValue(false);
+    const handlers = getRouteHandlers(coursesRouter, '/:id/textbook-structure', 'put');
+    const res = await runHandlers(
+      handlers,
+      {
+        params: { id: 3 },
+        user: { id: 9 },
+        body: {
+          nodes: [
+            {
+              id: 'tn-1',
+              slug: 'Ch1',
+              file: 'Ch1.html',
+              kind: 'chapter',
+              displayTitle: 'Arguments',
+              parentId: null,
+              sortIndex: 0,
+              hidden: false,
+            },
+          ],
+        },
+      },
+      createRes()
+    );
+    expect(res.statusCode).toBe(403);
+  });
+
+  test('PUT textbook-practice-links upserts for instructor', async () => {
+    requireInstructorOrAdmin.mockResolvedValue(true);
+    const links = [
+      {
+        id: 'link-1',
+        textbookSlug: 'Ch1',
+        sectionId: null,
+        practiceId: 12,
+        label: 'Practice',
+        match: null,
+      },
+    ];
+    linksUpsert.mockResolvedValue([{}]);
+    linksFindByPk.mockResolvedValue({
+      links,
+      updated_at: '2026-01-01T00:00:00.000Z',
+    });
+
+    const handlers = getRouteHandlers(coursesRouter, '/:id/textbook-practice-links', 'put');
+    const res = await runHandlers(
+      handlers,
+      {
+        params: { id: 3 },
+        user: { id: 9 },
+        body: { links },
+      },
+      createRes()
+    );
+
+    expect(linksUpsert).toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+    expect(res.body.usingDefaults).toBe(false);
+    expect(res.body.links).toEqual(links);
+  });
+});

--- a/models/CourseTextbookPracticeLinks.js
+++ b/models/CourseTextbookPracticeLinks.js
@@ -1,0 +1,39 @@
+import { DataTypes, Model } from 'sequelize';
+
+/**
+ * Course-scoped textbook ↔ practice link overrides.
+ * Absence of a row means the client should use seeded link templates.
+ */
+export default function initCourseTextbookPracticeLinks(sequelize) {
+  class CourseTextbookPracticeLinks extends Model {}
+
+  CourseTextbookPracticeLinks.init(
+    {
+      course_id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        allowNull: false,
+      },
+      links: {
+        type: DataTypes.JSONB,
+        allowNull: false,
+      },
+      updated_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+      updated_by: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+      },
+    },
+    {
+      sequelize,
+      tableName: 'course_textbook_practice_links',
+      timestamps: false,
+    }
+  );
+
+  return CourseTextbookPracticeLinks;
+}

--- a/models/CourseTextbookStructure.js
+++ b/models/CourseTextbookStructure.js
@@ -1,0 +1,39 @@
+import { DataTypes, Model } from 'sequelize';
+
+/**
+ * Course-scoped textbook TOC overrides (order, titles, hierarchy).
+ * Absence of a row means the client should use BookML bundle defaults.
+ */
+export default function initCourseTextbookStructure(sequelize) {
+  class CourseTextbookStructure extends Model {}
+
+  CourseTextbookStructure.init(
+    {
+      course_id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        allowNull: false,
+      },
+      nodes: {
+        type: DataTypes.JSONB,
+        allowNull: false,
+      },
+      updated_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+      updated_by: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+      },
+    },
+    {
+      sequelize,
+      tableName: 'course_textbook_structures',
+      timestamps: false,
+    }
+  );
+
+  return CourseTextbookStructure;
+}

--- a/models/index.js
+++ b/models/index.js
@@ -12,6 +12,8 @@ import initAssignmentExtension from './AssignmentExtension.js';
 import initAssignmentQuestionOverride from './AssignmentQuestionOverride.js';
 import initAccommodation from './Accommodation.js';
 import initAssignmentGrade from './AssignmentGrade.js';
+import initCourseTextbookStructure from './CourseTextbookStructure.js';
+import initCourseTextbookPracticeLinks from './CourseTextbookPracticeLinks.js';
 
 const User = initUser(sequelize);
 const Course = initCourse(sequelize);
@@ -26,6 +28,8 @@ const AssignmentExtension = initAssignmentExtension(sequelize);
 const AssignmentQuestionOverride = initAssignmentQuestionOverride(sequelize);
 const Accommodation = initAccommodation(sequelize);
 const AssignmentGrade = initAssignmentGrade(sequelize);
+const CourseTextbookStructure = initCourseTextbookStructure(sequelize);
+const CourseTextbookPracticeLinks = initCourseTextbookPracticeLinks(sequelize);
 
 // Associations
 User.hasMany(CourseEnrollment, { foreignKey: 'user_id' });
@@ -96,6 +100,14 @@ AssignmentGrade.belongsTo(User, { foreignKey: 'user_id' });
 User.hasMany(AssignmentGrade, { foreignKey: 'graded_by', as: 'gradedAssignments' });
 AssignmentGrade.belongsTo(User, { foreignKey: 'graded_by', as: 'gradedBy' });
 
+Course.hasOne(CourseTextbookStructure, { foreignKey: 'course_id' });
+CourseTextbookStructure.belongsTo(Course, { foreignKey: 'course_id' });
+CourseTextbookStructure.belongsTo(User, { foreignKey: 'updated_by', as: 'updatedBy' });
+
+Course.hasOne(CourseTextbookPracticeLinks, { foreignKey: 'course_id' });
+CourseTextbookPracticeLinks.belongsTo(Course, { foreignKey: 'course_id' });
+CourseTextbookPracticeLinks.belongsTo(User, { foreignKey: 'updated_by', as: 'updatedBy' });
+
 export {
   sequelize,
   User,
@@ -111,4 +123,6 @@ export {
   AssignmentQuestionOverride,
   Accommodation,
   AssignmentGrade,
+  CourseTextbookStructure,
+  CourseTextbookPracticeLinks,
 };

--- a/routes/courses.js
+++ b/routes/courses.js
@@ -5,6 +5,8 @@ import {
   AssignmentExtension,
   Course,
   CourseEnrollment,
+  CourseTextbookPracticeLinks,
+  CourseTextbookStructure,
   User,
   sequelize,
 } from '../models/index.js';
@@ -12,6 +14,10 @@ import { formatDueDateEastern } from '../utils/easternDate.js';
 import { addDays, computeDeadlinePolicy } from '../utils/assignmentPolicy.js';
 import { handleValidationResult } from '../middleware/validation.js';
 import { courseIdParam } from '../validators/common.js';
+import {
+  textbookPracticeLinksBody,
+  textbookStructureBody,
+} from '../validators/textbook.js';
 import { isSystemAdmin } from '../utils/authorization.js';
 import { requireInstructorOrAdmin } from './instructor.js';
 
@@ -189,5 +195,159 @@ router.get('/:id/enrollments', [courseIdParam, handleValidationResult], async (r
     next(error);
   }
 });
+
+router.get(
+  '/:id/textbook-structure',
+  [courseIdParam, handleValidationResult],
+  async (req, res, next) => {
+    try {
+      const courseId = req.params.id;
+      if (!(await requireEnrollmentOrAdmin(courseId, req.user))) {
+        return res.status(403).json({ message: 'Enrollment required' });
+      }
+
+      const row = await CourseTextbookStructure.findByPk(courseId);
+      return res.json({
+        courseId: Number(courseId),
+        nodes: row?.nodes ?? null,
+        usingDefaults: !row,
+        updatedAt: row?.updated_at ?? null,
+      });
+    } catch (error) {
+      return next(error);
+    }
+  }
+);
+
+router.put(
+  '/:id/textbook-structure',
+  [courseIdParam, ...textbookStructureBody, handleValidationResult],
+  async (req, res, next) => {
+    try {
+      const courseId = req.params.id;
+      if (!(await requireInstructorOrAdmin(courseId, req.user.id))) {
+        return res.status(403).json({ message: 'Instructor or admin access required' });
+      }
+
+      const nodes = Array.isArray(req.body.nodes) ? req.body.nodes : [];
+      await CourseTextbookStructure.upsert({
+        course_id: courseId,
+        nodes,
+        updated_at: new Date(),
+        updated_by: req.user.id,
+      });
+      const row = await CourseTextbookStructure.findByPk(courseId);
+
+      return res.json({
+        courseId: Number(courseId),
+        nodes: row?.nodes ?? nodes,
+        usingDefaults: false,
+        updatedAt: row?.updated_at ?? null,
+      });
+    } catch (error) {
+      return next(error);
+    }
+  }
+);
+
+router.delete(
+  '/:id/textbook-structure',
+  [courseIdParam, handleValidationResult],
+  async (req, res, next) => {
+    try {
+      const courseId = req.params.id;
+      if (!(await requireInstructorOrAdmin(courseId, req.user.id))) {
+        return res.status(403).json({ message: 'Instructor or admin access required' });
+      }
+
+      await CourseTextbookStructure.destroy({ where: { course_id: courseId } });
+      return res.json({
+        courseId: Number(courseId),
+        nodes: null,
+        usingDefaults: true,
+        updatedAt: null,
+      });
+    } catch (error) {
+      return next(error);
+    }
+  }
+);
+
+router.get(
+  '/:id/textbook-practice-links',
+  [courseIdParam, handleValidationResult],
+  async (req, res, next) => {
+    try {
+      const courseId = req.params.id;
+      if (!(await requireEnrollmentOrAdmin(courseId, req.user))) {
+        return res.status(403).json({ message: 'Enrollment required' });
+      }
+
+      const row = await CourseTextbookPracticeLinks.findByPk(courseId);
+      return res.json({
+        courseId: Number(courseId),
+        links: row?.links ?? null,
+        usingDefaults: !row,
+        updatedAt: row?.updated_at ?? null,
+      });
+    } catch (error) {
+      return next(error);
+    }
+  }
+);
+
+router.put(
+  '/:id/textbook-practice-links',
+  [courseIdParam, ...textbookPracticeLinksBody, handleValidationResult],
+  async (req, res, next) => {
+    try {
+      const courseId = req.params.id;
+      if (!(await requireInstructorOrAdmin(courseId, req.user.id))) {
+        return res.status(403).json({ message: 'Instructor or admin access required' });
+      }
+
+      const links = Array.isArray(req.body.links) ? req.body.links : [];
+      await CourseTextbookPracticeLinks.upsert({
+        course_id: courseId,
+        links,
+        updated_at: new Date(),
+        updated_by: req.user.id,
+      });
+      const row = await CourseTextbookPracticeLinks.findByPk(courseId);
+
+      return res.json({
+        courseId: Number(courseId),
+        links: row?.links ?? links,
+        usingDefaults: false,
+        updatedAt: row?.updated_at ?? null,
+      });
+    } catch (error) {
+      return next(error);
+    }
+  }
+);
+
+router.delete(
+  '/:id/textbook-practice-links',
+  [courseIdParam, handleValidationResult],
+  async (req, res, next) => {
+    try {
+      const courseId = req.params.id;
+      if (!(await requireInstructorOrAdmin(courseId, req.user.id))) {
+        return res.status(403).json({ message: 'Instructor or admin access required' });
+      }
+
+      await CourseTextbookPracticeLinks.destroy({ where: { course_id: courseId } });
+      return res.json({
+        courseId: Number(courseId),
+        links: null,
+        usingDefaults: true,
+        updatedAt: null,
+      });
+    } catch (error) {
+      return next(error);
+    }
+  }
+);
 
 export default router;

--- a/validators/textbook.js
+++ b/validators/textbook.js
@@ -1,0 +1,82 @@
+import { body } from 'express-validator';
+
+const STRUCTURE_KINDS = new Set([
+  'cover',
+  'preface',
+  'part',
+  'chapter',
+  'appendix',
+  'backmatter',
+]);
+
+export const textbookStructureBody = [
+  body('nodes')
+    .isArray()
+    .withMessage('nodes must be an array'),
+  body('nodes.*.id')
+    .isString()
+    .trim()
+    .notEmpty()
+    .withMessage('each node requires an id'),
+  body('nodes.*.slug')
+    .isString()
+    .trim()
+    .notEmpty()
+    .withMessage('each node requires a slug'),
+  body('nodes.*.file')
+    .optional({ nullable: true })
+    .isString()
+    .withMessage('file must be a string'),
+  body('nodes.*.kind')
+    .isString()
+    .custom((value) => STRUCTURE_KINDS.has(value))
+    .withMessage(`kind must be one of: ${[...STRUCTURE_KINDS].join(', ')}`),
+  body('nodes.*.displayTitle')
+    .isString()
+    .withMessage('displayTitle must be a string'),
+  body('nodes.*.parentId')
+    .optional({ nullable: true })
+    .custom((value) => value === null || typeof value === 'string')
+    .withMessage('parentId must be a string or null'),
+  body('nodes.*.sortIndex')
+    .isInt()
+    .toInt()
+    .withMessage('sortIndex must be an integer'),
+  body('nodes.*.hidden')
+    .optional()
+    .isBoolean()
+    .toBoolean()
+    .withMessage('hidden must be a boolean'),
+];
+
+export const textbookPracticeLinksBody = [
+  body('links')
+    .isArray()
+    .withMessage('links must be an array'),
+  body('links.*.id')
+    .isString()
+    .trim()
+    .notEmpty()
+    .withMessage('each link requires an id'),
+  body('links.*.textbookSlug')
+    .isString()
+    .trim()
+    .notEmpty()
+    .withMessage('each link requires textbookSlug'),
+  body('links.*.sectionId')
+    .optional({ nullable: true })
+    .custom((value) => value === null || typeof value === 'string')
+    .withMessage('sectionId must be a string or null'),
+  body('links.*.practiceId')
+    .optional({ nullable: true })
+    .custom((value) => value === null || typeof value === 'string' || typeof value === 'number')
+    .withMessage('practiceId must be a string, number, or null'),
+  body('links.*.label')
+    .optional({ nullable: true })
+    .custom((value) => value === null || typeof value === 'string')
+    .withMessage('label must be a string or null'),
+  body('links.*.match')
+    .optional({ nullable: true })
+    .custom((value) => value === null || (typeof value === 'object' && !Array.isArray(value)))
+    .withMessage('match must be an object or null'),
+];

--- a/validators/textbook.js
+++ b/validators/textbook.js
@@ -47,6 +47,11 @@ export const textbookStructureBody = [
     .isBoolean()
     .toBoolean()
     .withMessage('hidden must be a boolean'),
+  body('nodes.*.navigable')
+    .optional()
+    .isBoolean()
+    .toBoolean()
+    .withMessage('navigable must be a boolean'),
 ];
 
 export const textbookPracticeLinksBody = [


### PR DESCRIPTION
## Summary
- Add course-scoped API for textbook structure and practice↔chapter links (JSONB docs per course).
- Enrolled users can read; instructors/admins can PUT/DELETE overrides.
- Missing row = use frontend defaults (no override stored).

## Endpoints
- `GET|PUT|DELETE /api/courses/:id/textbook-structure`
- `GET|PUT|DELETE /api/courses/:id/textbook-practice-links`

## Deploy
Run this against Postgres before shipping (tables are not auto-created):

```sql
CREATE TABLE IF NOT EXISTS course_textbook_structures (
  course_id INTEGER PRIMARY KEY REFERENCES courses(id) ON DELETE CASCADE,
  nodes JSONB NOT NULL,
  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
  updated_by INTEGER REFERENCES users(id) ON DELETE SET NULL
);

CREATE TABLE IF NOT EXISTS course_textbook_practice_links (
  course_id INTEGER PRIMARY KEY REFERENCES courses(id) ON DELETE CASCADE,
  links JSONB NOT NULL,
  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
  updated_by INTEGER REFERENCES users(id) ON DELETE SET NULL
);